### PR TITLE
CALS-5923: Replace access token refresh by token introspection during Perry validation flow in Cognito MODE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ project.ext {
     projectMajorVersion = '3.0.0'
     mainclass = 'gov.ca.cwds.PerryApplication'
     targetDockerHubOrganization = System.env.DOCKERHUB_ORG ?: 'cwds'
-    cwdsModelVersion = '0.6.4_517-RC'
+    cwdsModelVersion = '0.6.4_533-RC'
 
     // assume that Windows users use the Docker Toolbox
     buildEnv = System.env.BUILD_ENV ?: (Os.isFamily(Os.FAMILY_WINDOWS) ? 'WIN_DEV' : 'JENKINS')

--- a/config/cognito.groovy
+++ b/config/cognito.groovy
@@ -2,7 +2,7 @@ def attribute = {name -> idpToken.UserAttributes?.find {it.Name.equalsIgnoreCase
 
 universalUserToken.userId = attribute("CUSTOM:RACFID")?.toUpperCase()
 
-universalUserToken.roles = attribute("custom:appRole")?.split('\\s*:\\s*') as HashSet
+universalUserToken.roles = attribute("zoneinfo")?.split('\\s*:\\s*') as HashSet
 
 if(!universalUserToken.roles) {
     universalUserToken.roles = new HashSet<>()

--- a/src/main/java/gov/ca/cwds/config/api/sp/PerrySpConfiguration.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/PerrySpConfiguration.java
@@ -1,0 +1,32 @@
+package gov.ca.cwds.config.api.sp;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.context.annotation.RequestScope;
+
+
+@Configuration
+@Order(1)
+@EnableWebSecurity
+public class PerrySpConfiguration extends WebSecurityConfigurerAdapter {
+  @Autowired
+  private SpApiSecurityFilter filter;
+  @Autowired
+  private SpApiAuthenticationErrorHandler errorHandler;
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http.antMatcher("/authn/validate*").authorizeRequests().anyRequest().authenticated()
+        .and().addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling().authenticationEntryPoint(errorHandler);
+
+  }
+}

--- a/src/main/java/gov/ca/cwds/config/api/sp/SpApiAuthenticationErrorHandler.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/SpApiAuthenticationErrorHandler.java
@@ -1,7 +1,9 @@
 package gov.ca.cwds.config.api.sp;
 
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -9,7 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class SpApiAuthenticationErrorHandler implements AuthenticationEntryPoint {
   @Override
-  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+    response.getOutputStream().print(HttpStatus.UNAUTHORIZED.getReasonPhrase());
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
   }
 }

--- a/src/main/java/gov/ca/cwds/config/api/sp/SpApiAuthenticationErrorHandler.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/SpApiAuthenticationErrorHandler.java
@@ -1,0 +1,15 @@
+package gov.ca.cwds.config.api.sp;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpApiAuthenticationErrorHandler implements AuthenticationEntryPoint {
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}

--- a/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
@@ -44,7 +44,7 @@ public class SpApiSecurityFilter extends AbstractPreAuthenticatedProcessingFilte
           SerializationUtils.deserialize(perryTokenEntity.getSecurityContext()),
           Collections.singletonList(new SimpleGrantedAuthority("SP_API_CLIENT")));
     } catch (Exception e) {
-      throw new BadCredentialsException("invalid token");
+      throw new BadCredentialsException("invalid token", e);
     }
   }
 

--- a/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
@@ -37,18 +37,15 @@ public class SpApiSecurityFilter extends AbstractPreAuthenticatedProcessingFilte
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-    PerryTokenEntity perryTokenEntity = tokenService.getPerryToken((String) authentication.getPrincipal());
-    if (perryTokenEntity == null) {
-      fail();
+    try {
+      PerryTokenEntity perryTokenEntity = tokenService.getPerryToken((String) authentication.getPrincipal());
+      return new PreAuthenticatedAuthenticationToken(
+          perryTokenEntity.getUser(),
+          SerializationUtils.deserialize(perryTokenEntity.getSecurityContext()),
+          Collections.singletonList(new SimpleGrantedAuthority("SP_API_CLIENT")));
+    } catch (Exception e) {
+      throw new BadCredentialsException("invalid token");
     }
-
-    return new PreAuthenticatedAuthenticationToken(
-        perryTokenEntity.getUser(),
-        SerializationUtils.deserialize(perryTokenEntity.getSecurityContext()),
-        Collections.singletonList(new SimpleGrantedAuthority("SP_API_CLIENT")));
   }
 
-  private void fail() {
-    throw new BadCredentialsException("invalid token");
-  }
 }

--- a/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
+++ b/src/main/java/gov/ca/cwds/config/api/sp/SpApiSecurityFilter.java
@@ -1,0 +1,54 @@
+package gov.ca.cwds.config.api.sp;
+
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
+import gov.ca.cwds.data.reissue.model.PerryTokenEntity;
+import gov.ca.cwds.service.TokenService;
+import org.apache.commons.lang3.SerializationUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpApiSecurityFilter extends AbstractPreAuthenticatedProcessingFilter implements AuthenticationManager {
+  private static final String TOKEN_PARAMETER_NAME = "token";
+  @Autowired
+  private TokenService tokenService;
+
+  public SpApiSecurityFilter() {
+    setAuthenticationManager(this);
+  }
+
+  @Override
+  protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+    return request.getParameter(TOKEN_PARAMETER_NAME);
+  }
+
+  @Override
+  protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+    return "N/A";
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    PerryTokenEntity perryTokenEntity = tokenService.getPerryToken((String) authentication.getPrincipal());
+    if (perryTokenEntity == null) {
+      fail();
+    }
+
+    return new PreAuthenticatedAuthenticationToken(
+        perryTokenEntity.getUser(),
+        SerializationUtils.deserialize(perryTokenEntity.getSecurityContext()),
+        Collections.singletonList(new SimpleGrantedAuthority("SP_API_CLIENT")));
+  }
+
+  private void fail() {
+    throw new BadCredentialsException("invalid token");
+  }
+}

--- a/src/main/java/gov/ca/cwds/data/reissue/TokenRepository.java
+++ b/src/main/java/gov/ca/cwds/data/reissue/TokenRepository.java
@@ -22,7 +22,7 @@ public interface TokenRepository extends JpaRepository<PerryTokenEntity, String>
   long deleteByCreatedDateBefore(Timestamp date);
 
   @Modifying
-  @Query("UPDATE PerryTokenEntity pte SET pte.ssoToken = ?2 WHERE pte.token = ?1")
-  int updateSsoToken(String token, String ssoToken);
+  @Query("UPDATE PerryTokenEntity pte SET pte.ssoToken = ?2, pte.securityContext = ?3 WHERE pte.token = ?1")
+  int updateSsoToken(String token, String ssoToken, byte[] securityContext);
 
 }

--- a/src/main/java/gov/ca/cwds/data/reissue/model/PerryTokenEntity.java
+++ b/src/main/java/gov/ca/cwds/data/reissue/model/PerryTokenEntity.java
@@ -24,6 +24,8 @@ public class PerryTokenEntity implements Serializable {
   @Column(name = "created_date", nullable = false)
   @Temporal(TemporalType.TIMESTAMP)
   private Date createdDate = new Date();
+  @Column(name = "security_context", length = 20000, nullable = false)
+  private byte[] securityContext;
 
   public String getUser() {
     return user;
@@ -73,4 +75,11 @@ public class PerryTokenEntity implements Serializable {
     this.token = token;
   }
 
+  public byte[] getSecurityContext() {
+    return securityContext;
+  }
+
+  public void setSecurityContext(byte[] securityContext) {
+    this.securityContext = securityContext;
+  }
 }

--- a/src/main/java/gov/ca/cwds/service/LoginServiceImpl.java
+++ b/src/main/java/gov/ca/cwds/service/LoginServiceImpl.java
@@ -24,7 +24,7 @@ public class LoginServiceImpl implements LoginService {
     UniversalUserToken userToken = (UniversalUserToken) securityContext.getAuthentication().getPrincipal();
     String ssoToken = ssoService.getSsoToken();
     String identity = identityMappingService.map(userToken, providerId);
-    return tokenService.issueAccessCode(userToken, ssoToken, identity);
+    return tokenService.issueAccessCode(userToken, ssoToken, identity, ssoService.getSecurityContext());
   }
 
   @Override
@@ -37,7 +37,7 @@ public class LoginServiceImpl implements LoginService {
     PerryTokenEntity perryTokenEntity = tokenService.getPerryToken(perryToken);
     String currentSsoToken = ssoService.validate(perryTokenEntity.getSsoToken());
     if (!currentSsoToken.equals(perryTokenEntity.getSsoToken())) {
-      tokenService.updateSsoToken(perryToken, currentSsoToken);
+      tokenService.updateSsoToken(perryToken, currentSsoToken, ssoService.getSecurityContext());
     }
     return perryTokenEntity.getJsonToken();
   }

--- a/src/main/java/gov/ca/cwds/service/TokenService.java
+++ b/src/main/java/gov/ca/cwds/service/TokenService.java
@@ -1,20 +1,21 @@
 package gov.ca.cwds.service;
 
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import gov.ca.cwds.PerryProperties;
 import gov.ca.cwds.UniversalUserToken;
 import gov.ca.cwds.data.reissue.TokenRepository;
 import gov.ca.cwds.data.reissue.model.PerryTokenEntity;
 import gov.ca.cwds.rest.api.domain.PerryException;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Created by TPT2 on 10/27/2017.
@@ -26,7 +27,7 @@ public class TokenService {
   private TokenRepository tokenRepository;
   private RandomValueStringGenerator generator = new RandomValueStringGenerator();
 
-  public String issueAccessCode(UniversalUserToken userToken, String ssoToken, String jsonToken) {
+  public String issueAccessCode(UniversalUserToken userToken, String ssoToken, String jsonToken, Serializable securityContext) {
     String accessCode = generator.generate();
     PerryTokenEntity perryTokenEntity = new PerryTokenEntity();
     perryTokenEntity.setUser(userToken.getUserId());
@@ -34,6 +35,7 @@ public class TokenService {
     perryTokenEntity.setSsoToken(ssoToken);
     perryTokenEntity.setJsonToken(jsonToken);
     perryTokenEntity.setToken(userToken.getToken());
+    perryTokenEntity.setSecurityContext(SerializationUtils.serialize(securityContext));
     deleteExpiredRecords();
     tokenRepository.save(perryTokenEntity);
     return accessCode;
@@ -62,8 +64,8 @@ public class TokenService {
     return perryTokenEntity.getToken();
   }
 
-  public void updateSsoToken(String token, String  ssoToken) {
-    tokenRepository.updateSsoToken(token, ssoToken);
+  public void updateSsoToken(String token, String ssoToken, Serializable context) {
+    tokenRepository.updateSsoToken(token, ssoToken, SerializationUtils.serialize(context));
   }
 
   public String deleteToken(String token) {

--- a/src/main/java/gov/ca/cwds/service/sso/OAuth2Service.java
+++ b/src/main/java/gov/ca/cwds/service/sso/OAuth2Service.java
@@ -1,6 +1,7 @@
 package gov.ca.cwds.service.sso;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import gov.ca.cwds.rest.api.domain.PerryException;
@@ -9,9 +10,11 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
@@ -69,7 +72,7 @@ public class OAuth2Service implements SsoService {
 
   @Override
   public String validate(String ssoToken) {
-    OAuth2RestTemplate restTemplate = userRestTemplate(ssoToken);
+    OAuth2RestTemplate restTemplate = userRestTemplate();
     doPost(restTemplate, resourceServerProperties.getTokenInfoUri(), ssoToken);
     return restTemplate.getOAuth2ClientContext().getAccessToken().getValue();
   }
@@ -82,6 +85,39 @@ public class OAuth2Service implements SsoService {
   @Override
   public String getSsoToken() {
     return clientContext.getAccessToken().getValue();
+  }
+
+  @Override
+  public Serializable getSecurityContext() {
+    Serializable apiSecurityContext = getApiSecurityContext();
+    return apiSecurityContext != null ? apiSecurityContext : getWebSecurityContext();
+  }
+
+  private Serializable getApiSecurityContext() {
+    try {
+      Object credential = SecurityContextHolder.getContext().getAuthentication().getCredentials();
+      if(credential instanceof OAuth2ClientContext) {
+        return (Serializable) credential;
+      }
+      return null;
+    }catch (Exception e) {
+      return null;
+    }
+  }
+
+  private Serializable getWebSecurityContext() {
+    if(clientContext != null) {
+      DefaultOAuth2ClientContext context = new DefaultOAuth2ClientContext(clientContext.getAccessTokenRequest());
+      context.setAccessToken(clientContext.getAccessToken());
+      return context;
+    }
+    return null;
+  }
+
+  private OAuth2RestTemplate userRestTemplate() {
+    return new OAuth2RestTemplate(
+        resourceDetails,
+        (OAuth2ClientContext) getSecurityContext());
   }
 
   private OAuth2RestTemplate userRestTemplate(String accessToken) {

--- a/src/main/java/gov/ca/cwds/service/sso/SsoService.java
+++ b/src/main/java/gov/ca/cwds/service/sso/SsoService.java
@@ -1,5 +1,6 @@
 package gov.ca.cwds.service.sso;
 
+import java.io.Serializable;
 import java.util.Map;
 
 public interface SsoService {
@@ -7,4 +8,5 @@ public interface SsoService {
   String validate(String ssoToken);
   void invalidate(String ssoToken);
   String getSsoToken();
+  Serializable getSecurityContext();
 }

--- a/src/main/java/gov/ca/cwds/service/sso/custom/form/FormService.java
+++ b/src/main/java/gov/ca/cwds/service/sso/custom/form/FormService.java
@@ -1,5 +1,6 @@
 package gov.ca.cwds.service.sso.custom.form;
 
+import java.io.Serializable;
 import java.util.Map;
 import gov.ca.cwds.UniversalUserToken;
 import gov.ca.cwds.config.Constants;
@@ -28,6 +29,12 @@ public class FormService implements SsoService {
   public void invalidate(String ssoToken) {
 
   }
+
+  @Override
+  public Serializable getSecurityContext() {
+    return SecurityContextHolder.getContext();
+  }
+
 
   @Override
   public String getSsoToken() {

--- a/src/test/java/gov/ca/cwds/service/TokenServiceTest.java
+++ b/src/test/java/gov/ca/cwds/service/TokenServiceTest.java
@@ -101,6 +101,6 @@ public class TokenServiceTest {
     UniversalUserToken universalUserToken = new UniversalUserToken();
     universalUserToken.setUserId(USER_ID);
     universalUserToken.setToken(perryToken);
-    return tokenService.issueAccessCode(universalUserToken, accessToken.getValue(), "");
+    return tokenService.issueAccessCode(universalUserToken, accessToken.getValue(), "", "");
   }
 }


### PR DESCRIPTION
### JIRA Issue Link
- [CALS-5923: Perry: Replace access token refresh by token introspection during Perry validation flow in Cognito MODE](https://osi-cwds.atlassian.net/browse/CALS-5923)

### Technical Description
<!--- Provide a technical description with context for those that don't know what this pull request is about.-->

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!--- Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!--- Describe impact on automated deployment if any. Put N/A if not applicable.-->

### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
