### PR TITLE
COG-93: sub added to jsonToken

### DIFF
--- a/config/default.groovy
+++ b/config/default.groovy
@@ -35,7 +35,8 @@ if (authorization) {
             county_code    : governmentEntityType.countyCd,
             county_cws_code: governmentEntityType.sysId,
             privileges     : privileges + user.permissions,
-            authorityCodes : authorityCodes]
+            authorityCodes : authorityCodes,
+            sub            : user.parameters["sub"]]
 
 }
 //NON-RACFID USER
@@ -51,7 +52,8 @@ else {
                  county_code    : cwsCounty?.countyCd,
                  county_cws_code: cwsCounty?.sysId,
                  county_name    : countyName,
-                 privileges     : user.permissions]
+                 privileges     : user.permissions,
+                 sub            : user.parameters["sub"]]
 
     //NON-RACFID CALS USER
     if (user.roles?.contains("CALS-external-worker")) {

--- a/src/test/java/gov/ca/cwds/service/scripts/DefaultMappingCalsTest.java
+++ b/src/test/java/gov/ca/cwds/service/scripts/DefaultMappingCalsTest.java
@@ -15,6 +15,7 @@ public class DefaultMappingCalsTest extends BaseScriptTest {
     universalUserToken.setParameter("given_name", "first");
     universalUserToken.setParameter("family_name", "last");
     universalUserToken.setParameter("email", "e-mail");
+    universalUserToken.setParameter("sub", "test-sub");
     return universalUserToken;
   }
 

--- a/src/test/java/gov/ca/cwds/service/scripts/DefaultMappingTest.java
+++ b/src/test/java/gov/ca/cwds/service/scripts/DefaultMappingTest.java
@@ -12,6 +12,7 @@ public class DefaultMappingTest extends BaseScriptTest {
     UniversalUserToken result = new UniversalUserToken();
     result.setUserId("userId");
     result.getRoles().addAll(Arrays.asList("role1", "role2"));
+    result.setParameter("sub", "test-sub");
     result.getPermissions().addAll(Arrays.asList("permission1", "permission2"));
     return result;
   }

--- a/src/test/resources/scripts/default/default-cals.json
+++ b/src/test/resources/scripts/default/default-cals.json
@@ -1,1 +1,1 @@
-{"user":"uuid","roles":["CALS-external-worker"],"first_name":"first","last_name":"last","email":"e-mail","county_code":"99","county_cws_code":1126,"county_name":"State of California","privileges":["CWS Case Management System","Resource Management"]}
+{"user":"uuid","roles":["CALS-external-worker"],"first_name":"first","last_name":"last","email":"e-mail","county_code":"99","county_cws_code":1126,"county_name":"State of California","privileges":["CWS Case Management System","Resource Management"],"sub":"test-sub"}

--- a/src/test/resources/scripts/default/default.groovy
+++ b/src/test/resources/scripts/default/default.groovy
@@ -35,7 +35,8 @@ if (authorization) {
             county_code    : governmentEntityType.countyCd,
             county_cws_code: governmentEntityType.sysId,
             privileges     : privileges + user.permissions,
-            authorityCodes : authorityCodes]
+            authorityCodes : authorityCodes,
+            sub            : user.parameters["sub"]]
 
 }
 //NON-RACFID USER
@@ -51,7 +52,8 @@ else {
                  county_code    : cwsCounty?.countyCd,
                  county_cws_code: cwsCounty?.sysId,
                  county_name    : countyName,
-                 privileges     : user.permissions]
+                 privileges     : user.permissions,
+                 sub            : user.parameters["sub"]]
 
     //NON-RACFID CALS USER
     if (user.roles?.contains("CALS-external-worker")) {

--- a/src/test/resources/scripts/default/default.json
+++ b/src/test/resources/scripts/default/default.json
@@ -1,1 +1,1 @@
-{"user":"userabc","first_name":"John","last_name":"Smith","roles":["role1","role2","Supervisor"],"staffId":"q1p","county_name":"Marin","county_code":"21","county_cws_code":1088,"privileges":["Countywide Read","permission1","permission2"],"authorityCodes":["S"]}
+{"user":"userabc","first_name":"John","last_name":"Smith","roles":["role1","role2","Supervisor"],"staffId":"q1p","county_name":"Marin","county_code":"21","county_cws_code":1088,"privileges":["Countywide Read","permission1","permission2"],"authorityCodes":["S"],"sub":"test-sub"}


### PR DESCRIPTION
### JIRA Issue Link
- [COG-93: an administrator should not be able to go into edit mode on their own account
](https://osi-cwds.atlassian.net/browse/COG-93)

### Technical Description
<!--- Provide a technical description with context for those that don't know what this pull request is about.-->
Cognito property 'sub' is added to the jsonToken so we can get this info for current logged in user via validate service

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!--- Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!--- Describe impact on automated deployment if any. Put N/A if not applicable.-->

### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
