### PR TITLE
COG-383: content type is set to APPLICATION_JSON

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/SearchService.java
+++ b/src/main/java/gov/ca/cwds/idm/service/SearchService.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -73,7 +75,10 @@ public class SearchService {
       throw new IllegalArgumentException("User operation type is null");
     }
 
-    HttpEntity<User> requestEntity = new HttpEntity<>(user);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<User> requestEntity = new HttpEntity<>(user, headers);
+
     String urlTemplate = getUrlTemplate(operation);
 
     Map<String, String> params = new HashMap<>();

--- a/src/test/java/gov/ca/cwds/idm/service/SearchServiceTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/SearchServiceTest.java
@@ -5,9 +5,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
 
 import gov.ca.cwds.idm.dto.User;
 import gov.ca.cwds.idm.persistence.model.OperationType;
@@ -87,6 +89,7 @@ public class SearchServiceTest {
             requestTo(
                 "http://localhost/dora/users/user/" + USER_ID + "/_create?token=" + SSO_TOKEN))
         .andExpect(method(HttpMethod.PUT))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andRespond(
             request -> new MockClientHttpResponse(DORA_RESPONSE.getBytes(), HttpStatus.CREATED));
 
@@ -102,6 +105,7 @@ public class SearchServiceTest {
     mockServer
         .expect(requestTo("http://localhost/dora/users/user/" + USER_ERROR_ID + "?token=" + SSO_TOKEN))
         .andExpect(method(HttpMethod.PUT))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andRespond(
         request -> new MockClientHttpResponse("error".getBytes(), HttpStatus.INTERNAL_SERVER_ERROR));
 


### PR DESCRIPTION
### JIRA Issue Link
- [COG-383: Update Elastic Search 'users' index using Dora REST webservice during Cognito user insert and update.](https://osi-cwds.atlassian.net/browse/COG-383)

### Technical Description
Request content type is fixed

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
