### PR TITLE
COG-383: create in ES fix related to auto-generated fields

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
@@ -102,8 +102,7 @@ public class IdmServiceImpl implements IdmService {
   @Override
   public String createUser(User user) {
     String id = cognitoServiceFacade.createUser(user);
-    user.setId(id);
-    createUserInSearch(user);
+    createUserInSearch(id);
     return id;
   }
 
@@ -187,10 +186,10 @@ public class IdmServiceImpl implements IdmService {
     }
   }
 
-  private void createUserInSearch(User user) {
-    String id = user.getId();
+  private void createUserInSearch(String id) {
     try {
-      searchService.createUser(user);
+      User createdUser = findUser(id);
+      searchService.createUser(createdUser);
     } catch (Exception e) {
       String msg = messages.get(UNABLE_CREATE_IDM_USER_IN_ES, id);
       LOGGER.error(msg, e);

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacade.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacade.java
@@ -147,8 +147,7 @@ public class CognitoServiceFacade {
   }
 
   public UserType getCognitoUserById(String id) {
-    AdminGetUserRequest request =
-        new AdminGetUserRequest().withUsername(id).withUserPoolId(properties.getUserpool());
+    AdminGetUserRequest request = createAdminGetUserRequest(id);
     AdminGetUserResult agur;
 
     agur = executeInCognito(identityProvider::adminGetUser, request, id);
@@ -160,6 +159,10 @@ public class CognitoServiceFacade {
         .withUserCreateDate(agur.getUserCreateDate())
         .withUserLastModifiedDate(agur.getUserLastModifiedDate())
         .withUserStatus(agur.getUserStatus());
+  }
+
+  public AdminGetUserRequest createAdminGetUserRequest(String id) {
+    return new AdminGetUserRequest().withUsername(id).withUserPoolId(properties.getUserpool());
   }
 
   /**


### PR DESCRIPTION
### JIRA Issue Link
- [COG-383: Update Elastic Search 'users' index using Dora REST webservice during Cognito user insert and update.](https://osi-cwds.atlassian.net/browse/COG-383)

### Technical Description
Bug fix for User auto-generated fields during create

### Tests
- [ ] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
