### PR TITLE
CANS-385 Perry: support wildcards in callback URLs white list

### DIFF
--- a/src/main/java/gov/ca/cwds/service/WhiteList.java
+++ b/src/main/java/gov/ca/cwds/service/WhiteList.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import org.springframework.util.AntPathMatcher;
 
 /**
  * Created by dmitry.rudenko on 9/18/2017.
@@ -15,9 +16,11 @@ public class WhiteList {
 
   PerryProperties configuration;
 
+  private AntPathMatcher pathMatcher = new AntPathMatcher();
+
   public void validate(String param, String url) {
-    if (!disabled(configuration.getWhiteList())
-        && !(configuration.getWhiteList().contains(url)
+    List<String> patterns = configuration.getWhiteList();
+    if (!disabled(patterns) && !(anyMatch(url, patterns)
         || configuration.getHomePageUrl().equals(url))) {
       throw new PerryException(param + ": " + url + " is not registered");
     }
@@ -30,6 +33,10 @@ public class WhiteList {
 
   private boolean disabled(List<String> whiteList) {
     return whiteList.size() == 1 && whiteList.contains("*");
+  }
+
+  private boolean anyMatch(String url, List<String> patterns) {
+    return patterns.stream().anyMatch(pattern -> pathMatcher.match(pattern, url));
   }
 
 }

--- a/src/test/java/gov/ca/cwds/service/WhiteListTest.java
+++ b/src/test/java/gov/ca/cwds/service/WhiteListTest.java
@@ -2,6 +2,7 @@ package gov.ca.cwds.service;
 
 import gov.ca.cwds.PerryProperties;
 import gov.ca.cwds.rest.api.domain.PerryException;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -34,5 +35,39 @@ public class WhiteListTest {
     perryProperties.setWhiteList("*");
     whiteList.configuration = perryProperties;
     whiteList.validate("", "url3");
+    whiteList.validate("", "url3/path");
+  }
+
+  @Test
+  public void testWildcards() {
+    WhiteList whiteList = new WhiteList();
+    PerryProperties perryProperties = new PerryProperties();
+    whiteList.configuration = perryProperties;
+
+    perryProperties.setWhiteList("**/test_1*");
+    whiteList.validate("", "http://test_12");
+
+    perryProperties.setWhiteList("http://tests/path*");
+    whiteList.validate("", "http://tests/path_1");
+
+    perryProperties.setWhiteList("http://tests2/*/inside");
+    whiteList.validate("", "http://tests2/path/inside");
+    whiteList.validate("", "http://tests2/path_1/inside");
+
+    perryProperties.setWhiteList("http://tests2/**/*.*");
+    whiteList.validate("", "http://tests2/path/page.html");
+    whiteList.validate("", "http://tests2/path/page.js");
+
+    perryProperties.setWhiteList("http://tests3/**");
+    whiteList.validate("", "http://tests3/path/inside?param=value");
+    whiteList.validate("", "http://tests3/path/inside/more?param=value");
+
+    try {
+      perryProperties.setWhiteList("http://tests3/**");
+      whiteList.validate("", "http://tests_other/path");
+      Assert.fail();
+    } catch (PerryException pe) {
+      // Do nothing
+    }
   }
 }


### PR DESCRIPTION
### JIRA Issue Link
- [CANS-385 Perry: support wildcards in callback URLs white list](https://osi-cwds.atlassian.net/browse/CANS-385)

### Technical Description
AntPathMatcher was applied for WhiteList which allows using wildcards for callback URLs. Documentation added to Perry Dev Guide.

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes


### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
