### PR TITLE
CANS-388. Fix for abac results filtering by the same nested object

### DIFF
--- a/api-security/src/test/java/gov/ca/cwds/security/FullyImplementedAuthorizerTest.java
+++ b/api-security/src/test/java/gov/ca/cwds/security/FullyImplementedAuthorizerTest.java
@@ -8,6 +8,7 @@ import gov.ca.cwds.testapp.domain.CaseDTO;
 import gov.ca.cwds.testapp.service.FullyImplementedAuthorizerTestService;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -117,8 +118,10 @@ public class FullyImplementedAuthorizerTest extends AbstractApiSecurityTest {
     clearCallsCounts();
     Set<CaseDTO> result = testService.testReturnFilteredByNestedId();
     assertCallsCounts(0, 0, 1, 0);
-    assert result.size() == 1;
-    assert result.iterator().next().getCaseObject().getName().equals("valid");
+    assert result.size() == 2;
+    final Iterator<CaseDTO> iterator = result.iterator();
+    assert iterator.next().getCaseObject().getName().equals("valid");
+    assert iterator.next().getCaseObject().getName().equals("valid");
   }
 
   @Test
@@ -126,8 +129,22 @@ public class FullyImplementedAuthorizerTest extends AbstractApiSecurityTest {
     clearCallsCounts();
     List<CaseDTO> result = testService.testReturnFilteredByNestedObject();
     assertCallsCounts(0, 0, 0, 1);
-    assert result.size() == 1;
-    assert result.iterator().next().getCaseObject().getName().equals("valid");
+    assert result.size() == 2;
+    final Iterator<CaseDTO> iterator = result.iterator();
+    assert iterator.next().getCaseObject().getName().equals("valid");
+    assert iterator.next().getCaseObject().getName().equals("valid");
+  }
+
+  @Test
+  public void testReturnFilteredByNestedSoleObject() {
+    clearCallsCounts();
+    List<CaseDTO> result = testService.testReturnFilteredByNestedSoleObject();
+    assertCallsCounts(0, 0, 0, 1);
+    assert result.size() == 2;
+    final Iterator<CaseDTO> iterator = result.iterator();
+    final Case caseObject0 = iterator.next().getCaseObject();
+    final Case caseObject1 = iterator.next().getCaseObject();
+    assert caseObject0 == caseObject1;
   }
 
   @Test

--- a/api-security/src/test/java/gov/ca/cwds/security/authorizer/FullyImplementedAuthorizer.java
+++ b/api-security/src/test/java/gov/ca/cwds/security/authorizer/FullyImplementedAuthorizer.java
@@ -21,7 +21,7 @@ public class FullyImplementedAuthorizer extends BaseAuthorizer<Case, Long> {
   }
 
   private boolean isAuthorized(Long id) {
-    return id == 2L;
+    return id == 2L || id == 3L;
   }
 
   @Override

--- a/api-security/src/test/java/gov/ca/cwds/testapp/service/FullyImplementedAuthorizerTestService.java
+++ b/api-security/src/test/java/gov/ca/cwds/testapp/service/FullyImplementedAuthorizerTestService.java
@@ -36,6 +36,8 @@ public interface FullyImplementedAuthorizerTestService {
 
   List<CaseDTO> testReturnFilteredByNestedObject();
 
+  List<CaseDTO> testReturnFilteredByNestedSoleObject();
+
   List<Case> testFilterArgument(List<Case> caseList);
 
   List<CaseDTO> testFilterArgumentByNestedId(List<CaseDTO> caseDTOList);

--- a/api-security/src/test/java/gov/ca/cwds/testapp/service/FullyImplementedAuthorizerTestServiceImpl.java
+++ b/api-security/src/test/java/gov/ca/cwds/testapp/service/FullyImplementedAuthorizerTestServiceImpl.java
@@ -87,12 +87,15 @@ public class FullyImplementedAuthorizerTestServiceImpl implements
   @Authorize("case:full:caseDTO.caseObject.id")
   public Set<CaseDTO> testReturnFilteredByNestedId() {
     Set<CaseDTO> result = new HashSet<>();
-    CaseDTO caseDTO = new CaseDTO();
-    caseDTO.setCaseObject(new Case(1L, "invalid"));
-    result.add(caseDTO);
-    caseDTO = new CaseDTO();
-    caseDTO.setCaseObject(new Case(2L, "valid"));
-    result.add(caseDTO);
+    CaseDTO case0 = new CaseDTO();
+    case0.setCaseObject(new Case(1L, "invalid"));
+    result.add(case0);
+    CaseDTO case1 = new CaseDTO();
+    case1.setCaseObject(new Case(2L, "valid"));
+    result.add(case1);
+    CaseDTO case2 = new CaseDTO();
+    case2.setCaseObject(new Case(3L, "valid"));
+    result.add(case2);
     return result;
   }
 
@@ -100,12 +103,32 @@ public class FullyImplementedAuthorizerTestServiceImpl implements
   @Authorize("case:full:caseDTO.caseObject")
   public List<CaseDTO> testReturnFilteredByNestedObject() {
     List<CaseDTO> result = new ArrayList<>();
-    CaseDTO caseDTO = new CaseDTO();
-    caseDTO.setCaseObject(new Case(1L, "invalid"));
-    result.add(caseDTO);
-    caseDTO = new CaseDTO();
-    caseDTO.setCaseObject(new Case(2L, "valid"));
-    result.add(caseDTO);
+    CaseDTO case0 = new CaseDTO();
+    case0.setCaseObject(new Case(1L, "invalid"));
+    result.add(case0);
+    CaseDTO case1 = new CaseDTO();
+    case1.setCaseObject(new Case(2L, "valid"));
+    result.add(case1);
+    CaseDTO case2 = new CaseDTO();
+    case2.setCaseObject(new Case(3L, "valid"));
+    result.add(case2);
+    return result;
+  }
+
+  @Override
+  @Authorize("case:full:caseDTO.caseObject")
+  public List<CaseDTO> testReturnFilteredByNestedSoleObject() {
+    List<CaseDTO> result = new ArrayList<>();
+    CaseDTO case0 = new CaseDTO();
+    case0.setCaseObject(new Case(1L, "invalid"));
+    result.add(case0);
+    CaseDTO case1 = new CaseDTO();
+    final Case validCase = new Case(2L, "valid");
+    case1.setCaseObject(validCase);
+    result.add(case1);
+    CaseDTO case2 = new CaseDTO();
+    case2.setCaseObject(validCase);
+    result.add(case2);
     return result;
   }
 


### PR DESCRIPTION
### JIRA Issue Link
- [CANS-388N: Null pointer exception instead of 404 error when using invalid assessment id in GET /assessments/{id}](https://osi-cwds.atlassian.net/browse/CANS-388)

### Technical Description
Fix for abac results filtering by **the same** nested object

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!--- Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!--- Describe impact on automated deployment if any. Put N/A if not applicable.-->

### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
