### PR TITLE
COG-561: Ensure no duplicate user in CARES when going from Inactive to Active status

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/IdmResource.java
+++ b/src/main/java/gov/ca/cwds/idm/IdmResource.java
@@ -202,7 +202,12 @@ public class IdmResource {
       return ResponseEntity.noContent().build();
     } catch (UserNotFoundPerryException e) {
       return ResponseEntity.notFound().build();
-    } catch (PartialSuccessException e) {
+    } catch (UserIdmValidationException e) {
+      return createCustomResponseEntity(
+          HttpStatus.BAD_REQUEST,
+          e.getErrorCode(),
+          e.getMessage());
+    }catch (PartialSuccessException e) {
       return createCustomResponseEntity(
           HttpStatus.INTERNAL_SERVER_ERROR,
           e.getErrorCode(),

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacade.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacade.java
@@ -56,6 +56,8 @@ public interface CognitoServiceFacade {
    */
   boolean changeUserEnabledStatus(UserEnableStatusRequest request);
 
+  boolean isActiveRacfIdPresent(String racfId);
+
   /**
    * Resend the invitation message to a user that already exists and reset the expiration limit
    * on the user's account by admin.

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeImpl.java
@@ -3,6 +3,7 @@ package gov.ca.cwds.idm.service.cognito;
 import static gov.ca.cwds.idm.persistence.ns.OperationType.GET;
 import static gov.ca.cwds.idm.persistence.ns.OperationType.UPDATE;
 import static gov.ca.cwds.idm.service.cognito.UserLastAuthenticatedTimestampExtractor.extractUserLastAuthenticatedTimestamp;
+import static gov.ca.cwds.idm.service.cognito.util.CognitoUsersSearchCriteriaUtil.composeToGetFirstPageByRacfId;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.EMAIL_DELIVERY;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.buildCreateUserAttributes;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.createPermissionsAttribute;
@@ -14,6 +15,7 @@ import static gov.ca.cwds.service.messages.MessageCode.UNABLE_CREATE_NEW_IDM_USE
 import static gov.ca.cwds.service.messages.MessageCode.USER_NOT_FOUND_BY_ID_IN_IDM;
 import static gov.ca.cwds.service.messages.MessageCode.USER_WITH_EMAIL_EXISTS_IN_IDM;
 import static gov.ca.cwds.util.Utils.toLowerCase;
+import static gov.ca.cwds.util.Utils.toUpperCase;
 
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResult;
@@ -55,7 +57,9 @@ import gov.ca.cwds.rest.api.domain.UserNotFoundPerryException;
 import gov.ca.cwds.service.messages.MessagesService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -66,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 @Service(value = "cognitoServiceFacade")
 @Profile("idm")
@@ -113,7 +118,7 @@ public class CognitoServiceFacadeImpl implements CognitoServiceFacade {
     } catch (InvalidParameterException e) {
       String msg = messages.get(IDM_USER_VALIDATION_FAILED);
       LOGGER.error(msg, e);
-      throw new UserIdmValidationException(msg, e);
+      throw new UserIdmValidationException(IDM_USER_VALIDATION_FAILED, msg, e);
     }
   }
 
@@ -282,6 +287,20 @@ public class CognitoServiceFacadeImpl implements CognitoServiceFacade {
       }
     }
     return executed;
+  }
+
+  @Override
+  public boolean isActiveRacfIdPresent(String racfId) {
+    Collection<UserType> cognitoUsersByRacfId =
+        searchAllPages(composeToGetFirstPageByRacfId(toUpperCase(racfId)));
+    return !CollectionUtils.isEmpty(cognitoUsersByRacfId)
+        && isActiveUserPresent(cognitoUsersByRacfId);
+  }
+
+  private static boolean isActiveUserPresent(Collection<UserType> cognitoUsers) {
+    return cognitoUsers
+        .stream()
+        .anyMatch(userType -> Objects.equals(userType.getEnabled(), Boolean.TRUE));
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoUtils.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoUtils.java
@@ -120,4 +120,8 @@ public class CognitoUtils {
   public static String getRACFId(UserType user) {
     return CognitoUtils.getAttributeValue(user, RACFID_CUSTOM.getName());
   }
+
+  public static boolean canChangeToEnableActiveStatus(Boolean newEnabled, Boolean currentEnabled) {
+    return newEnabled != null && !newEnabled.equals(currentEnabled) && newEnabled;
+  }
 }

--- a/src/main/java/gov/ca/cwds/idm/service/validate/UserActivationRule.java
+++ b/src/main/java/gov/ca/cwds/idm/service/validate/UserActivationRule.java
@@ -1,0 +1,38 @@
+package gov.ca.cwds.idm.service.validate;
+
+import static gov.ca.cwds.service.messages.MessageCode.ACTIVE_USER_WITH_RAFCID_EXISTS_IN_IDM;
+import static gov.ca.cwds.service.messages.MessageCode.NO_USER_WITH_RACFID_IN_CWSCMS;
+
+import gov.ca.cwds.idm.service.cognito.CognitoServiceFacade;
+import gov.ca.cwds.rest.api.domain.UserIdmValidationException;
+import gov.ca.cwds.service.CwsUserInfoService;
+import gov.ca.cwds.service.dto.CwsUserInfo;
+import gov.ca.cwds.service.messages.MessagesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/** Validates all rules when changing enable status of user from Inactive to Active status. */
+@Component
+@Profile("idm")
+public class UserActivationRule implements ValidationRule {
+  @Autowired private MessagesService messages;
+  @Autowired private CwsUserInfoService cwsUserInfoService;
+  @Autowired private CognitoServiceFacade cognitoServiceFacade;
+
+  @Override
+  public void performValidation(String racfId) {
+    CwsUserInfo cwsUser = cwsUserInfoService.getCwsUserByRacfId(racfId);
+    // validates users not active in CWS cannot be set to Active in CWS CARES
+    if (cwsUser == null) {
+      String msg = messages.get(NO_USER_WITH_RACFID_IN_CWSCMS, racfId);
+      throw new UserIdmValidationException(NO_USER_WITH_RACFID_IN_CWSCMS, msg);
+    }
+
+    // validates no other Active users with same RACFID in CWS CARES exist
+    if (cognitoServiceFacade.isActiveRacfIdPresent(racfId)) {
+      String msg = messages.get(ACTIVE_USER_WITH_RAFCID_EXISTS_IN_IDM, racfId);
+      throw new UserIdmValidationException(ACTIVE_USER_WITH_RAFCID_EXISTS_IN_IDM, msg);
+    }
+  }
+}

--- a/src/main/java/gov/ca/cwds/idm/service/validate/ValidationRule.java
+++ b/src/main/java/gov/ca/cwds/idm/service/validate/ValidationRule.java
@@ -1,0 +1,8 @@
+package gov.ca.cwds.idm.service.validate;
+
+/** Validates all rules imposed by the class. */
+public interface ValidationRule {
+
+  /** Performs the validation here. */
+  void performValidation(String str);
+}

--- a/src/main/java/gov/ca/cwds/rest/api/domain/UserIdmValidationException.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/UserIdmValidationException.java
@@ -1,14 +1,23 @@
 package gov.ca.cwds.rest.api.domain;
 
+import gov.ca.cwds.service.messages.MessageCode;
+
 public class UserIdmValidationException extends RuntimeException {
 
   private static final long serialVersionUID = 3122648071078983603L;
+  private final MessageCode errorCode;
 
-  public UserIdmValidationException(String message) {
-    super(message);
+  public UserIdmValidationException(MessageCode errorCode, String message, Throwable e) {
+    super(message, e);
+    this.errorCode = errorCode;
   }
 
-  public UserIdmValidationException(String message, Throwable e) {
-    super(message, e);
+  public UserIdmValidationException(MessageCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public MessageCode getErrorCode() {
+    return errorCode;
   }
 }

--- a/src/test/java/gov/ca/cwds/idm/TestCognitoServiceFacade.java
+++ b/src/test/java/gov/ca/cwds/idm/TestCognitoServiceFacade.java
@@ -61,6 +61,10 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
   static final String SOME_PAGINATION_TOKEN = "somePaginationToken";
   static final String ABSENT_USER_ID = "absentUserId";
   static final String ERROR_USER_ID = "errorUserId";
+  static final String INACTIVE_USER_WITH_NO_ACTIVE_RACFID_IN_CMS =
+      "17067e4e-270f-4623-b86c-b4d4fa527z79";
+  static final String INACTIVE_USER_WITH_ACTIVE_RACFID_IN_CMS =
+      "17067e4e-270f-4623-b86c-b4d4fa524f38";
   static final String USER_WITH_INACTIVE_STATUS_COGNITO =
       "17067e4e-270f-4623-b86c-b4d4fa527a22";
   static final String STATE_ADMIN_ID = "2d9369b4-5855-4a2c-95f7-3617fab1496a";
@@ -212,6 +216,38 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
             "SMITHB3",
             null);
 
+    TestUser userWithNoActiveRacfIdInCms =
+        testUser(
+            INACTIVE_USER_WITH_NO_ACTIVE_RACFID_IN_CMS,
+            Boolean.FALSE,
+            "CONFIRMED",
+            date(2018, 5, 3),
+            date(2018, 5, 31),
+            "smith4th@gmail.com",
+            "Smith",
+            "Forth",
+            WithMockCustomUser.COUNTY,
+            "test",
+            null,
+            "NOIDCMS",
+            null);
+
+    TestUser userWithActiveRacfIdAInCms =
+        testUser(
+            INACTIVE_USER_WITH_ACTIVE_RACFID_IN_CMS,
+            Boolean.FALSE,
+            "CONFIRMED",
+            date(2018, 5, 3),
+            date(2018, 5, 31),
+            "smith5th@gmail.com",
+            "Smith",
+            "Fifth",
+            WithMockCustomUser.COUNTY,
+            "test",
+            null,
+            "SMITHBO",
+            null);
+
     TestUser newSuccessUser =
         testUser(
             NEW_USER_SUCCESS_ID,
@@ -261,6 +297,10 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
     setSearchByRacfidRequestAndResult(userWithNoPhoneExtension);
 
     setSearchByRacfidRequestAndResult(userWithEnableStatusInactiveInCognito);
+
+    setSearchByRacfidRequestAndResult(userWithNoActiveRacfIdInCms);
+
+    setSearchByRacfidRequestAndReturnResults(userWithActiveRacfIdAInCms, userWithRacfidAndDbData);
 
     mockAdminListDevices();
   }
@@ -469,6 +509,19 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
             composeToGetFirstPageByAttribute(RACFID_STANDARD, testUser.getRacfId()));
 
     ListUsersResult result = new ListUsersResult().withUsers(userType(testUser));
+
+    when(cognito.listUsers(request)).thenReturn(result);
+
+    return request;
+  }
+
+  ListUsersRequest setSearchByRacfidRequestAndReturnResults(TestUser testUser1, TestUser testUser2) {
+
+    ListUsersRequest request =
+        composeListUsersRequest(
+            composeToGetFirstPageByAttribute(RACFID_STANDARD, testUser1.getRacfId()));
+
+    ListUsersResult result = new ListUsersResult().withUsers(userType(testUser1), userType(testUser2));
 
     when(cognito.listUsers(request)).thenReturn(result);
 

--- a/src/test/java/gov/ca/cwds/idm/service/validate/UserActivationRuleTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/validate/UserActivationRuleTest.java
@@ -1,0 +1,60 @@
+package gov.ca.cwds.idm.service.validate;
+
+import static gov.ca.cwds.service.messages.MessageCode.ACTIVE_USER_WITH_RAFCID_EXISTS_IN_IDM;
+import static gov.ca.cwds.service.messages.MessageCode.NO_USER_WITH_RACFID_IN_CWSCMS;
+import static org.mockito.Mockito.when;
+
+import gov.ca.cwds.idm.service.cognito.CognitoServiceFacade;
+import gov.ca.cwds.rest.api.domain.UserIdmValidationException;
+import gov.ca.cwds.service.CwsUserInfoService;
+import gov.ca.cwds.service.dto.CwsUserInfo;
+import gov.ca.cwds.service.messages.MessagesService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class UserActivationRuleTest {
+
+  private static final String ACTIVE_USER_WITH_RACFID_EXISTS_IN_COGNITO_ERROR_MSG =
+      "Active User with RACFID: SMITHBO exists in Cognito";
+  private static final String NO_ACTIVE_USER_WITH_RACFID_IN_CMS_ERROR_MSG =
+      "No user with RACFID: SMITHBO found in CWSCMS";
+  private String racfId = "SMITHBO";
+
+  @InjectMocks private UserActivationRule userActivationRule;
+  @Mock protected MessagesService messages;
+  @Mock protected CwsUserInfoService cwsUserInfoService;
+  @Mock protected CognitoServiceFacade cognitoServiceFacade;
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Before
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void performValidation_throwsNoRacfIdInCWS() {
+    when(cwsUserInfoService.getCwsUserByRacfId(racfId)).thenReturn(null);
+    when(messages.get(NO_USER_WITH_RACFID_IN_CWSCMS, racfId))
+        .thenReturn(NO_ACTIVE_USER_WITH_RACFID_IN_CMS_ERROR_MSG);
+    exception.expect(UserIdmValidationException.class);
+    exception.expectMessage(NO_ACTIVE_USER_WITH_RACFID_IN_CMS_ERROR_MSG);
+    userActivationRule.performValidation(racfId);
+  }
+
+  @Test
+  public void performValidation_throwsActiveRacfIdAlreadyInCognito() {
+    when(cwsUserInfoService.getCwsUserByRacfId(racfId)).thenReturn(new CwsUserInfo());
+    when(cognitoServiceFacade.isActiveRacfIdPresent(racfId)).thenReturn(true);
+    when(messages.get(ACTIVE_USER_WITH_RAFCID_EXISTS_IN_IDM, racfId))
+        .thenReturn(ACTIVE_USER_WITH_RACFID_EXISTS_IN_COGNITO_ERROR_MSG);
+    exception.expect(UserIdmValidationException.class);
+    exception.expectMessage(ACTIVE_USER_WITH_RACFID_EXISTS_IN_COGNITO_ERROR_MSG);
+    userActivationRule.performValidation(racfId);
+  }
+}

--- a/src/test/resources/fixtures/idm/update-user/active-user-with-same-racfid-in-cognito-error.json
+++ b/src/test/resources/fixtures/idm/update-user/active-user-with-same-racfid-in-cognito-error.json
@@ -1,0 +1,5 @@
+{
+  "status": "BAD_REQUEST",
+  "message": "Active User with RACFID: SMITHBO exists in Cognito",
+  "error_code": "CAP-028"
+}

--- a/src/test/resources/fixtures/idm/update-user/no-active-cws-user-error.json
+++ b/src/test/resources/fixtures/idm/update-user/no-active-cws-user-error.json
@@ -1,0 +1,5 @@
+{
+  "status": "BAD_REQUEST",
+  "message": "No user with RACFID: NOIDCMS found in CWSCMS",
+  "error_code": "CAP-003"
+}

--- a/src/test/resources/fixtures/idm/users-search/valid.json
+++ b/src/test/resources/fixtures/idm/users-search/valid.json
@@ -41,5 +41,27 @@
     "roles":[
       "CWS-worker"
     ]
+  },
+  {
+    "id": "17067e4e-270f-4623-b86c-b4d4fa524f38",
+    "first_name": "Smith",
+    "last_name": "Fifth",
+    "county_name": "Yolo",
+    "start_date": "1980-08-08",
+    "office_id": "JzoGSkE05I",
+    "phone_number": "4646464646",
+    "phone_extension_number": "11",
+    "email": "smith5th@gmail.com",
+    "user_create_date": "2018-05-03",
+    "user_last_modified_date": "2018-05-31",
+    "last_login_date_time": "2018-09-17 05:01:12",
+    "enabled": false,
+    "status": "CONFIRMED",
+    "racfid": "SMITHBO",
+    "permissions": [
+      "test"
+    ],
+    "roles":[
+    ]
   }
 ]


### PR DESCRIPTION
### JIRA Issue Link
- [COG-561: Ensure no duplicate user in CARES when going from Inactive to Active status](https://osi-cwds.atlassian.net/browse/COG-561)

### Technical Description
Added new validations to restrict activating users if the RACFID is inactive in CMS or if the RACFID is already active in Cognito.

### Tests
- [X] I have included unit tests 
- [X] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
N/A

### Technical debt
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
