### PR TITLE
COG-561: not apply validation if user does not have racfid

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
@@ -84,6 +84,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 @Service
 @Profile("idm")
@@ -125,7 +126,10 @@ public class IdmServiceImpl implements IdmService {
     UserType existedCognitoUser = cognitoServiceFacade.getCognitoUserById(userId);
 
     if (canChangeToEnableActiveStatus(updateUserDto.getEnabled(), existedCognitoUser.getEnabled())) {
-      validateActivateUser(CognitoUtils.getRACFId(existedCognitoUser));
+      String racfId = CognitoUtils.getRACFId(existedCognitoUser);
+      if (! StringUtils.isEmpty(racfId)) {
+        validateActivateUser(racfId);
+      }
     }
 
     ExecutionStatus updateAttributesStatus =

--- a/src/test/java/gov/ca/cwds/idm/IdmResourceTest.java
+++ b/src/test/java/gov/ca/cwds/idm/IdmResourceTest.java
@@ -14,6 +14,7 @@ import static gov.ca.cwds.idm.TestCognitoServiceFacade.ERROR_USER_ID;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.ES_ERROR_CREATE_USER_EMAIL;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.INACTIVE_USER_WITH_ACTIVE_RACFID_IN_CMS;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.INACTIVE_USER_WITH_NO_ACTIVE_RACFID_IN_CMS;
+import static gov.ca.cwds.idm.TestCognitoServiceFacade.INACTIVE_USER_WITH_NO_RACFID;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.NEW_USER_ES_FAIL_ID;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.NEW_USER_SUCCESS_ID;
 import static gov.ca.cwds.idm.TestCognitoServiceFacade.SOME_PAGINATION_TOKEN;
@@ -702,6 +703,28 @@ public class IdmResourceTest extends BaseIntegrationTest {
     verify(spySearchService, times(0)).updateUser(any(User.class));
     verify(cognito, times(0)).adminEnableUser(enableUserRequest);
     verifyDoraCalls(0);
+  }
+
+  @Test
+  @WithMockCustomUser
+  public void testValidationUpdateUserChangeInactiveToActive_withNoRacfIdForUser() throws Exception {
+    UserUpdate userUpdate = new UserUpdate();
+    userUpdate.setEnabled(Boolean.TRUE);
+    AdminEnableUserRequest enableUserRequest = setEnableUserRequestAndResult(INACTIVE_USER_WITH_NO_RACFID);
+    setDoraSuccess();
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.patch("/idm/users/" + INACTIVE_USER_WITH_NO_RACFID)
+                    .contentType(JSON_CONTENT_TYPE)
+                    .content(asJsonString(userUpdate)))
+            .andExpect(MockMvcResultMatchers.status().isNoContent())
+            .andReturn();
+
+    verify(spySearchService, times(1)).updateUser(any(User.class));
+    verify(cognito, times(1)).adminEnableUser(enableUserRequest);
+    verifyDoraCalls(1);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/idm/TestCognitoServiceFacade.java
+++ b/src/test/java/gov/ca/cwds/idm/TestCognitoServiceFacade.java
@@ -67,6 +67,8 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
       "17067e4e-270f-4623-b86c-b4d4fa524f38";
   static final String USER_WITH_INACTIVE_STATUS_COGNITO =
       "17067e4e-270f-4623-b86c-b4d4fa527a22";
+  static final String INACTIVE_USER_WITH_NO_RACFID =
+      "17067e4e-270f-4623-b86c-b4d4fa525d68";
   static final String STATE_ADMIN_ID = "2d9369b4-5855-4a2c-95f7-3617fab1496a";
   static final String COUNTY_ADMIN_ID = "c3702f4c113f1d2415447c8bfe8321d8df2d5151";
 
@@ -248,6 +250,22 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
             "SMITHBO",
             null);
 
+    TestUser inactiveUserWithNoRacfId =
+        testUser(
+            INACTIVE_USER_WITH_NO_RACFID,
+            Boolean.FALSE,
+            "CONFIRMED",
+            date(2018, 5, 3),
+            date(2018, 5, 31),
+            "smith6th@gmail.com",
+            "Smith",
+            "Sixth",
+            WithMockCustomUser.COUNTY,
+            "test",
+            null,
+            null,
+            null);
+
     TestUser newSuccessUser =
         testUser(
             NEW_USER_SUCCESS_ID,
@@ -299,6 +317,8 @@ public class TestCognitoServiceFacade extends CognitoServiceFacadeImpl {
     setSearchByRacfidRequestAndResult(userWithEnableStatusInactiveInCognito);
 
     setSearchByRacfidRequestAndResult(userWithNoActiveRacfIdInCms);
+
+    setSearchByRacfidRequestAndResult(inactiveUserWithNoRacfId);
 
     setSearchByRacfidRequestAndReturnResults(userWithActiveRacfIdAInCms, userWithRacfidAndDbData);
 

--- a/src/test/java/gov/ca/cwds/idm/service/IdmServiceImplTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/IdmServiceImplTest.java
@@ -300,7 +300,7 @@ public class IdmServiceImplTest {
   }
 
   @Test
-  public void performValidation_throwsNoRacfIdInCWS() {
+  public void testPerformValidation_throwsNoRacfIdInCWS() {
     final String NO_ACTIVE_USER_WITH_RACFID_IN_CMS_ERROR_MSG =
         "No user with RACFID: NOIDCMS found in CWSCMS";
     final String racfId = "NOIDCMS";
@@ -311,7 +311,7 @@ public class IdmServiceImplTest {
   }
 
   @Test
-  public void performValidation_throwsActiveRacfIdAlreadyInCognito() {
+  public void testPerformValidation_throwsActiveRacfIdAlreadyInCognito() {
     final String ACTIVE_USER_WITH_RACFID_EXISTS_IN_COGNITO_ERROR_MSG =
         "Active User with RACFID: SMITHBO exists in Cognito";
     final String racfId = "SMITHBO";


### PR DESCRIPTION
### JIRA Issue Link
- [COG-561: Ensure no duplicate user in CARES when going from Inactive to Active status](https://osi-cwds.atlassian.net/browse/COG-561)

### Technical Description
remove the validation if the user does not have racfid

### Tests
- [ ] I have included unit tests 
- [X] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
N/A

### Technical debt
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
