### PR TITLE
CANS-366: Perry: Build global session and security token timeout (Token Validate)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project.ext {
     projectMajorVersion = '4.0.0'
     mainclass = 'gov.ca.cwds.PerryApplication'
     targetDockerHubOrganization = System.env.DOCKERHUB_ORG ?: 'cwds'
-    cwdsModelVersion = '0.9.2_670-RC'
+    cwdsModelVersion = '0.9.2-SNAPSHOT'
     powerMockVersion = "1.7.3"
 
     // assume that Windows users use the Docker Toolbox

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project.ext {
     projectMajorVersion = '4.0.0'
     mainclass = 'gov.ca.cwds.PerryApplication'
     targetDockerHubOrganization = System.env.DOCKERHUB_ORG ?: 'cwds'
-    cwdsModelVersion = '0.9.4-SNAPSHOT'
+    cwdsModelVersion = '0.9.4_678-RC'
     powerMockVersion = "1.7.3"
 
     // assume that Windows users use the Docker Toolbox

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project.ext {
     projectMajorVersion = '4.0.0'
     mainclass = 'gov.ca.cwds.PerryApplication'
     targetDockerHubOrganization = System.env.DOCKERHUB_ORG ?: 'cwds'
-    cwdsModelVersion = '0.9.2-SNAPSHOT'
+    cwdsModelVersion = '0.9.4-SNAPSHOT'
     powerMockVersion = "1.7.3"
 
     // assume that Windows users use the Docker Toolbox

--- a/config/perry-dev.yml
+++ b/config/perry-dev.yml
@@ -63,7 +63,7 @@ perry:
     whiteList: ${WHITE_LIST:*}
     homePageUrl: ${HOME_PAGE_URL:/}
     showErrors: ${SHOW_ERRORS:true}
-    tokenRecordTimeout: ${TOKEN_RECORD_TIMEOUT:7} # days
+    tokenRecordTimeout: ${TOKEN_RECORD_TIMEOUT:240} # minutes
     liquibase:
       schema:
         change-log: classpath:/liquibase/perry_schema.xml

--- a/config/perry-prod.yml
+++ b/config/perry-prod.yml
@@ -71,7 +71,7 @@ perry:
     whiteList: ${WHITE_LIST:*} # urls separated by spaces.
     homePageUrl: ${HOME_PAGE_URL:/}
     showErrors: ${SHOW_ERRORS:true}
-    tokenRecordTimeout: ${TOKEN_RECORD_TIMEOUT:7} # days
+    tokenRecordTimeout: ${TOKEN_RECORD_TIMEOUT:240} # minutes
     idpMaxAttempts: ${IDP_MAX_ATTEMPTS:5} #amount of retries
     idpRetryTimeout: ${IDP_RETRY_TIMEOUT:500}  #milliseconds
     idpValidateInterval: ${IDP_VALIDATE_INTERVAL:2} #seconds

--- a/src/main/java/gov/ca/cwds/data/reissue/TokenRepository.java
+++ b/src/main/java/gov/ca/cwds/data/reissue/TokenRepository.java
@@ -21,4 +21,7 @@ public interface TokenRepository extends JpaRepository<PerryTokenEntity, String>
   @Modifying
   long deleteByCreatedDateBefore(Timestamp date);
 
+  @Modifying
+  long deleteByLastUsedDateBeforeOrLastUsedDateIsNull(Timestamp date);
+
 }

--- a/src/main/java/gov/ca/cwds/data/reissue/model/PerryTokenEntity.java
+++ b/src/main/java/gov/ca/cwds/data/reissue/model/PerryTokenEntity.java
@@ -25,6 +25,9 @@ public class PerryTokenEntity implements Serializable {
   @Column(name = "created_date", nullable = false)
   @Temporal(TemporalType.TIMESTAMP)
   private Date createdDate = new Date();
+  @Column(name = "last_used_date")
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date lastUsedDate;
   @Column(name = "security_context", length = 20000, nullable = false)
   private byte[] securityContext;
   @Column(name = "last_idp_validate_time")
@@ -93,5 +96,13 @@ public class PerryTokenEntity implements Serializable {
 
   public void setLastIdpValidateTime(Date lastIdpValidateTime) {
     this.lastIdpValidateTime = lastIdpValidateTime;
+  }
+
+  public Date getLastUsedDate() {
+    return lastUsedDate;
+  }
+
+  public void setLastUsedDate(Date lastUsedDate) {
+    this.lastUsedDate = lastUsedDate;
   }
 }

--- a/src/main/java/gov/ca/cwds/service/TokenService.java
+++ b/src/main/java/gov/ca/cwds/service/TokenService.java
@@ -115,7 +115,7 @@ public class TokenService {
 
   private void validateToken(PerryTokenEntity perryTokenEntity) {
     Date expirationDate =
-        DateUtils.addHours(perryTokenEntity.getLastUsedDate(), properties.getTokenRecordTimeout());
+        DateUtils.addMinutes(perryTokenEntity.getLastUsedDate(), properties.getTokenRecordTimeout());
     if (new Date().after(expirationDate)) {
       tokenRepository.delete(perryTokenEntity);
       throw new PerryException("Token " + perryTokenEntity.getToken() +

--- a/src/main/java/gov/ca/cwds/service/TokenService.java
+++ b/src/main/java/gov/ca/cwds/service/TokenService.java
@@ -42,6 +42,7 @@ public class TokenService {
     perryTokenEntity.setJsonToken(jsonToken);
     perryTokenEntity.setToken(userToken.getToken());
     perryTokenEntity.setSecurityContext(SerializationUtils.serialize(securityContext));
+    perryTokenEntity.setLastUsedDate(perryTokenEntity.getCreatedDate());
     deleteExpiredRecords();
     tokenRepository.save(perryTokenEntity);
     eventPublisher.publishEvent(new UserLoggedInEvent(userToken));
@@ -49,8 +50,9 @@ public class TokenService {
   }
 
   private void deleteExpiredRecords() {
-    Date createdDateTime = DateUtils.addDays(new Date(), -properties.getTokenRecordTimeout());
-    tokenRepository.deleteByCreatedDateBefore(new Timestamp(createdDateTime.getTime()));
+    Date validLastUsedDate = DateUtils.addMinutes(new Date(), -properties.getTokenRecordTimeout());
+    tokenRepository.deleteByLastUsedDateBeforeOrLastUsedDateIsNull(
+        new Timestamp(validLastUsedDate.getTime()));
   }
 
   public String getPerryTokenByAccessCode(String accessCode) {
@@ -87,7 +89,13 @@ public class TokenService {
   }
 
   public PerryTokenEntity getPerryToken(String token) {
-    return tokenRepository.findOne(token);
+    PerryTokenEntity perryTokenEntity = tokenRepository.findOne(token);
+    if(perryTokenEntity == null) {
+      throw new PerryException("token: " + token + " is not found");
+    }
+    validateToken(perryTokenEntity);
+    perryTokenEntity.setLastUsedDate(new Date());
+    return perryTokenEntity;
   }
 
   @Autowired
@@ -103,5 +111,15 @@ public class TokenService {
   @Autowired
   public void setEventPublisher(ApplicationEventPublisher eventPublisher) {
     this.eventPublisher = eventPublisher;
+  }
+
+  private void validateToken(PerryTokenEntity perryTokenEntity) {
+    Date expirationDate =
+        DateUtils.addHours(perryTokenEntity.getLastUsedDate(), properties.getTokenRecordTimeout());
+    if (new Date().after(expirationDate)) {
+      tokenRepository.delete(perryTokenEntity);
+      throw new PerryException("Token " + perryTokenEntity.getToken() +
+          " for user:" + perryTokenEntity.getUser() + " is expired");
+    }
   }
 }

--- a/src/test/java/gov/ca/cwds/service/TokenServiceTest.java
+++ b/src/test/java/gov/ca/cwds/service/TokenServiceTest.java
@@ -114,6 +114,20 @@ public class TokenServiceTest {
     validateLastUsedDate(new Date(), () -> tokenService.getPerryToken(perryToken));
   }
 
+  @Test(expected = PerryException.class)
+  @Transactional(value = "tokenTransactionManager")
+  public void testExpiredPerryToken() {
+    properties.setTokenRecordTimeout(0);
+    String accessCode = issueAccessCode();
+    String perryToken = tokenService.getPerryTokenByAccessCode(accessCode);
+    try {
+      tokenService.getPerryToken(perryToken);
+    } catch (PerryException e) {
+      assert tokenRepository.findAll().isEmpty();
+      throw e;
+    }
+  }
+
   private void validateLastUsedDate(Date minLastUsedDate, Supplier<PerryTokenEntity> perryTokenSupplier) {
     long minLastUsedDateTime = minLastUsedDate.getTime();
     PerryTokenEntity perryTokenEntity = perryTokenSupplier.get();

--- a/src/test/java/gov/ca/cwds/web/PerryDevModeTest.java
+++ b/src/test/java/gov/ca/cwds/web/PerryDevModeTest.java
@@ -34,7 +34,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
     "perry.identityProvider.idpMapping=config/cognito.groovy",
     "perry.serviceProviders.default.identityMapping=config/dev.groovy",
     "perry.serviceProviders.mfa.identityMapping=config/default.groovy",
-    "perry.jwt.timeout=10"
+    "perry.jwt.timeout=10",
+    "perry.tokenRecordTimeout=240"
 }, classes = {PerryApplication.class})
 public class PerryDevModeTest extends BaseIntegrationTest {
 

--- a/src/test/java/gov/ca/cwds/web/PerryMFALoginTest.java
+++ b/src/test/java/gov/ca/cwds/web/PerryMFALoginTest.java
@@ -58,7 +58,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
     "security.oauth2.resource.logoutTokenUri=http://logout.token.url",
     "perry.idpMaxAttempts=2",
     "idpRetryTimeout=0",
-    "idpValidateInterval=2"
+    "idpValidateInterval=2",
+    "perry.tokenRecordTimeout=240"
 }, classes = {PerryLoginTestConfiguration.class, PerryApplication.class})
 
 public class PerryMFALoginTest extends BaseIntegrationTest {


### PR DESCRIPTION
### JIRA Issue Link
- [CANS-366: Perry: Build global session and security token timeout (Token Validate)](https://osi-cwds.atlassian.net/browse/CANS-366)

### Technical Description
<!--- Provide a technical description with context for those that don't know what this pull request is about.-->

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!--- Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!--- Describe impact on automated deployment if any. Put N/A if not applicable.-->

### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
