### PR TITLE
COG-704 County admin should not be able to edit a state admin

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImpl.java
@@ -44,6 +44,10 @@ public class AuthorizationServiceImpl implements AuthorizationService {
       return false;
     }
     User user = getUserFromUserId(userId);
+    return canUpdateUser(user);
+  }
+
+  public boolean canUpdateUser(User user) {
     return adminRoleImplementorFactory.getAdminActionsAuthorizer(user).canUpdateUser();
   }
 

--- a/src/main/java/gov/ca/cwds/idm/service/role/implementor/CountyAdminAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/idm/service/role/implementor/CountyAdminAuthorizer.java
@@ -1,5 +1,6 @@
 package gov.ca.cwds.idm.service.role.implementor;
 
+import static gov.ca.cwds.idm.service.authorization.UserRolesService.isStateAdmin;
 import static gov.ca.cwds.idm.service.role.implementor.AuthorizationUtils.isPrincipalInTheSameCountyWith;
 
 import gov.ca.cwds.idm.dto.User;
@@ -25,7 +26,7 @@ class CountyAdminAuthorizer implements AdminActionsAuthorizer {
 
   @Override
   public boolean canUpdateUser() {
-    return isPrincipalInTheSameCountyWith(user);
+    return isPrincipalInTheSameCountyWith(user) && !isStateAdmin(user);
   }
 
   @Override

--- a/src/test/java/gov/ca/cwds/idm/IdmResourceTest.java
+++ b/src/test/java/gov/ca/cwds/idm/IdmResourceTest.java
@@ -1013,6 +1013,12 @@ public class IdmResourceTest extends BaseIntegrationTest {
 
   @Test
   @WithMockCustomUser
+  public void testUpdateUser_CountyAdminCannotUpdateStateAdmin() throws Exception {
+    assertUpdateUserUnauthorized(STATE_ADMIN_ID);
+  }
+
+  @Test
+  @WithMockCustomUser
   public void testUpdateUserNoChanges() throws Exception {
     assertUpdateNoChangesSuccess();
   }
@@ -1066,13 +1072,17 @@ public class IdmResourceTest extends BaseIntegrationTest {
   }
 
   private void assertUpdateUserUnauthorized() throws Exception {
+    assertUpdateUserUnauthorized(USER_WITH_RACFID_AND_DB_DATA_ID);
+  }
+
+  private void assertUpdateUserUnauthorized(String userId) throws Exception {
     UserUpdate userUpdate = new UserUpdate();
     userUpdate.setEnabled(Boolean.FALSE);
     userUpdate.setPermissions(toSet("RFA-rollout", "Hotline-rollout"));
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.patch("/idm/users/" + USER_WITH_RACFID_AND_DB_DATA_ID)
+            MockMvcRequestBuilders.patch("/idm/users/" + userId)
                 .contentType(JSON_CONTENT_TYPE)
                 .content(asJsonString(userUpdate)))
         .andExpect(MockMvcResultMatchers.status().isUnauthorized())

--- a/src/test/java/gov/ca/cwds/idm/service/AuthorizationTestHelper.java
+++ b/src/test/java/gov/ca/cwds/idm/service/AuthorizationTestHelper.java
@@ -14,6 +14,7 @@ public final class AuthorizationTestHelper {
 
   public static User user(String countyName, String officeId) {
     User user = new User();
+    user.setId("userId");
     user.setCountyName(countyName);
     user.setOfficeId(officeId);
     return user;
@@ -25,15 +26,10 @@ public final class AuthorizationTestHelper {
     return user;
   }
 
-  static User withRole(String role) {
-    User user = new User();
-    user.getRoles().add(role);
-    return user;
-  }
-
   public static UniversalUserToken admin(Set<String> roles, String countyName,
       Set<String> adminOfficeIds) {
     UniversalUserToken admin = new UniversalUserToken();
+    admin.setUserId("adminId");
     admin.setRoles(roles);
     admin.setParameter(COUNTY_NAME_PARAM, countyName);
     admin.setParameter(ADMIN_OFFICE_IDS_PARAM, adminOfficeIds);

--- a/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
@@ -135,4 +135,13 @@ public class AuthorizationServiceImplTest {
         user(toSet(COUNTY_ADMIN), "Yolo", "Yolo_3")));
   }
 
+  @Test
+  public void testCountyAdminCannotEditStateAdmin() {
+    when(getCurrentUser())
+        .thenReturn(admin(toSet(COUNTY_ADMIN), "Yolo", toSet("Yolo_1")));
+
+    assertFalse(service.canUpdateUser(user(toSet(STATE_ADMIN), "Yolo", "Yolo_1")));
+    assertFalse(service.canUpdateUser(user(toSet(STATE_ADMIN), "Yolo", "Yolo_2")));
+    assertFalse(service.canUpdateUser(user(toSet(STATE_ADMIN), "Madura", "Madura_1")));
+  }
 }

--- a/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
@@ -136,7 +136,7 @@ public class AuthorizationServiceImplTest {
   }
 
   @Test
-  public void testCountyAdminCannotEditStateAdmin() {
+  public void testCountyAdminCannotUpdateStateAdmin() {
     when(getCurrentUser())
         .thenReturn(admin(toSet(COUNTY_ADMIN), "Yolo", toSet("Yolo_1")));
 


### PR DESCRIPTION
### JIRA Issue Link
- [COG-704: County admin should not be able to edit a state admin](https://osi-cwds.atlassian.net/browse/COG-704)

### Technical Description
County admin should not be allowed to edit a state admin

### Tests
- [x] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
