### PR TITLE
COG-821: Office admin's ability to view profile of users belonging to other offices in same county

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/role/implementor/OfficeAdminAuthorizer.java
+++ b/src/main/java/gov/ca/cwds/idm/service/role/implementor/OfficeAdminAuthorizer.java
@@ -1,8 +1,6 @@
 package gov.ca.cwds.idm.service.role.implementor;
 
 import static gov.ca.cwds.idm.service.authorization.UserRolesService.isAdmin;
-import static gov.ca.cwds.idm.service.authorization.UserRolesService.isCountyAdmin;
-import static gov.ca.cwds.idm.service.authorization.UserRolesService.isStateAdmin;
 import static gov.ca.cwds.idm.service.role.implementor.AuthorizationUtils.isPrincipalInTheSameCountyWith;
 import static gov.ca.cwds.util.CurrentAuthenticatedUserUtil.getCurrentUserOfficeIds;
 
@@ -17,9 +15,7 @@ class OfficeAdminAuthorizer extends AbstractAdminActionsAuthorizer {
 
   @Override
   public boolean canViewUser() {
-    return isPrincipalInTheSameCountyWith(getUser())
-        && !userIsStateAdminFromOtherOffice()
-        && !userIsCountyAdminFromOtherOffice();
+    return isPrincipalInTheSameCountyWith(getUser());
   }
 
   @Override
@@ -37,18 +33,9 @@ class OfficeAdminAuthorizer extends AbstractAdminActionsAuthorizer {
     return isAdminInTheSameOfficeAsUser();
   }
 
-  private boolean userIsStateAdminFromOtherOffice() {
-    return isStateAdmin(getUser()) && !isAdminInTheSameOfficeAsUser();
-  }
-
-  private boolean userIsCountyAdminFromOtherOffice() {
-    return isCountyAdmin(getUser()) && !isAdminInTheSameOfficeAsUser();
-  }
-
   private boolean isAdminInTheSameOfficeAsUser() {
     String userOfficeId = getUser().getOfficeId();
     Set<String> adminOfficeIds = getCurrentUserOfficeIds();
     return userOfficeId != null && adminOfficeIds != null && adminOfficeIds.contains(userOfficeId);
   }
-
 }

--- a/src/test/java/gov/ca/cwds/idm/GetUserTest.java
+++ b/src/test/java/gov/ca/cwds/idm/GetUserTest.java
@@ -108,13 +108,13 @@ public class GetUserTest extends BaseIdmResourceTest {
   @Test
   @WithMockCustomUser(roles = {OFFICE_ADMIN}, adminOfficeIds = {"OtherOfficeId"})
   public void testGetOtherOfficeCountyAdminByOfficeAdmin() throws Exception {
-    assertGetUserUnauthorized(COUNTY_ADMIN_ID);
+    testGetValidUser(COUNTY_ADMIN_ID, "fixtures/idm/get-user/with-county-admin-id.json");
   }
 
   @Test
   @WithMockCustomUser(roles = {OFFICE_ADMIN}, adminOfficeIds = {"OtherOfficeId"})
   public void testGetOtherOfficeStateAdminByOfficeAdmin() throws Exception {
-    assertGetUserUnauthorized(STATE_ADMIN_ID);
+    testGetValidUser(STATE_ADMIN_ID, "fixtures/idm/get-user/with-state-admin-id.json");
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/authorization/AuthorizationServiceImplTest.java
@@ -160,9 +160,9 @@ public class AuthorizationServiceImplTest {
         user(toSet(STATE_ADMIN), "Yolo", "Yolo_1")));
     assertTrue(service.canViewUser(
         user(toSet(COUNTY_ADMIN), "Yolo", "Yolo_1")));
-    assertFalse(service.canViewUser(
+    assertTrue(service.canViewUser(
         user(toSet(STATE_ADMIN), "Yolo", "Yolo_3")));
-    assertFalse(service.canViewUser(
+    assertTrue(service.canViewUser(
         user(toSet(COUNTY_ADMIN), "Yolo", "Yolo_3")));
   }
 

--- a/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
+++ b/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
@@ -1,0 +1,32 @@
+{
+  "user": {
+    "id": "c3702f4c113f1d2415447c8bfe8321d8df2d5151",
+    "first_name": "Reddy",
+    "last_name": "Jkuser",
+    "county_name": "Yolo",
+    "office_id": "JzoGSkE05I",
+    "email": "jkuser@gmail.com",
+    "user_create_date": "2018-05-03",
+    "start_date": "1997-08-13",
+    "user_last_modified_date": "2018-05-31",
+    "enabled": true,
+    "status": "CONFIRMED",
+    "racfid": "MCALLUM",
+    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "phone_number": "4646464646",
+    "phone_extension_number": "11",
+    "permissions": [
+      "test"
+    ],
+    "roles": [
+      "County-admin"
+    ]
+  },
+  "edit_details": {
+    "editable": false,
+    "roles": {
+      "editable": false,
+      "possible_values": ["CWS-worker"]
+    }
+  }
+}

--- a/src/test/resources/fixtures/idm/get-user/with-state-admin-id.json
+++ b/src/test/resources/fixtures/idm/get-user/with-state-admin-id.json
@@ -1,0 +1,32 @@
+{
+  "user": {
+    "id": "2d9369b4-5855-4a2c-95f7-3617fab1496a",
+    "first_name": "Christina",
+    "last_name": "Yull",
+    "county_name": "Yolo",
+    "office_id": "JzoGSkE05I",
+    "email": "yull@gmail.com",
+    "user_create_date": "2018-05-03",
+    "start_date": "2017-11-06",
+    "user_last_modified_date": "2018-05-31",
+    "enabled": true,
+    "status": "CONFIRMED",
+    "racfid": "YULLC",
+    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "phone_number": "4646464646",
+    "phone_extension_number": "11",
+    "permissions": [
+      "test"
+    ],
+    "roles": [
+      "State-admin"
+    ]
+  },
+  "edit_details": {
+    "editable": false,
+    "roles": {
+      "editable": false,
+      "possible_values": ["CWS-worker"]
+    }
+  }
+}


### PR DESCRIPTION
### JIRA Issue Link
- [COG-821: Office admin's ability to view profile of users belonging to other offices in same county](https://osi-cwds.atlassian.net/browse/COG-821)

### Technical Description
We will allow an office admin to view the details of other Office, County admins in the SAME county.

### Tests
- [x] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
