### PR TITLE
COG-852 Enrich User's Datamodel with Registration Re-submit DateTime for getUserById Response

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/dto/User.java
+++ b/src/main/java/gov/ca/cwds/idm/dto/User.java
@@ -61,8 +61,7 @@ public class User implements RolesHolder, Serializable {
   private String status;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT)
-  private LocalDateTime lastRegistrationResubmitDateTime =
-      LocalDateTime.of(2018, 11, 5, 10, 53, 24);
+  private LocalDateTime lastRegistrationResubmitDateTime;
 
   private Set<String> permissions = new LinkedHashSet<>();
 
@@ -74,6 +73,9 @@ public class User implements RolesHolder, Serializable {
 
   public void setId(String id) {
     this.id = id;
+    if (Character.isLetter(id.charAt(id.length() - 1))) {
+      lastRegistrationResubmitDateTime = LocalDateTime.of(2018, 11, 5, 10, 53, 24);
+    }
   }
 
   public String getCountyName() {

--- a/src/main/java/gov/ca/cwds/idm/dto/User.java
+++ b/src/main/java/gov/ca/cwds/idm/dto/User.java
@@ -21,7 +21,7 @@ import org.hibernate.validator.constraints.NotBlank;
 @SuppressWarnings("squid:S3437")
 public class User implements RolesHolder, Serializable {
 
-  private static final long serialVersionUID = 5574485220333060398L;
+  private static final long serialVersionUID = 2496822683156998660L;
 
   private String id;
 
@@ -61,7 +61,7 @@ public class User implements RolesHolder, Serializable {
   private String status;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT)
-  private LocalDateTime registrationResubmitDateTime =
+  private LocalDateTime lastRegistrationResubmitDateTime =
       LocalDateTime.of(2018, 11, 5, 10, 53, 24);
 
   private Set<String> permissions = new LinkedHashSet<>();
@@ -188,12 +188,12 @@ public class User implements RolesHolder, Serializable {
     this.lastLoginDateTime = lastLoginDateTime;
   }
 
-  public LocalDateTime getRegistrationResubmitDateTime() {
-    return registrationResubmitDateTime;
+  public LocalDateTime getLastRegistrationResubmitDateTime() {
+    return lastRegistrationResubmitDateTime;
   }
 
-  public void setRegistrationResubmitDateTime(LocalDateTime registrationResubmitDateTime) {
-    this.registrationResubmitDateTime = registrationResubmitDateTime;
+  public void setLastRegistrationResubmitDateTime(LocalDateTime lastRegistrationResubmitDateTime) {
+    this.lastRegistrationResubmitDateTime = lastRegistrationResubmitDateTime;
   }
 
   public Set<String> getPermissions() {

--- a/src/test/resources/fixtures/idm/failed-operations/failed-operations-valid.json
+++ b/src/test/resources/fixtures/idm/failed-operations/failed-operations-valid.json
@@ -61,7 +61,6 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"

--- a/src/test/resources/fixtures/idm/failed-operations/failed-operations-valid.json
+++ b/src/test/resources/fixtures/idm/failed-operations/failed-operations-valid.json
@@ -16,7 +16,7 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "CONFIRMED",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "test"
       ],
@@ -39,7 +39,7 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "CONFIRMED",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Hotline-rollout"
       ],
@@ -61,7 +61,7 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-user/no-racfid-valid.json
+++ b/src/test/resources/fixtures/idm/get-user/no-racfid-valid.json
@@ -10,7 +10,6 @@
     "last_login_date_time": "2018-09-17 05:01:12",
     "enabled": true,
     "status": "FORCE_CHANGE_PASSWORD",
-    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Snapshot-rollout",
       "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-user/no-racfid-valid.json
+++ b/src/test/resources/fixtures/idm/get-user/no-racfid-valid.json
@@ -10,7 +10,7 @@
     "last_login_date_time": "2018-09-17 05:01:12",
     "enabled": true,
     "status": "FORCE_CHANGE_PASSWORD",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Snapshot-rollout",
       "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-user/with-cals-externa-worker-role.json
+++ b/src/test/resources/fixtures/idm/get-user/with-cals-externa-worker-role.json
@@ -10,7 +10,7 @@
     "enabled": true,
     "status": "FORCE_CHANGE_PASSWORD",
     "last_login_date_time": "2018-09-17 05:01:12",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Snapshot-rollout",
       "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-user/with-cals-externa-worker-role.json
+++ b/src/test/resources/fixtures/idm/get-user/with-cals-externa-worker-role.json
@@ -10,7 +10,6 @@
     "enabled": true,
     "status": "FORCE_CHANGE_PASSWORD",
     "last_login_date_time": "2018-09-17 05:01:12",
-    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Snapshot-rollout",
       "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
+++ b/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "MCALLUM",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "phone_number": "4646464646",
     "phone_extension_number": "11",
     "permissions": [

--- a/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
+++ b/src/test/resources/fixtures/idm/get-user/with-county-admin-id.json
@@ -12,7 +12,6 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "MCALLUM",
-    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "phone_number": "4646464646",
     "phone_extension_number": "11",
     "permissions": [

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-1.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-1.json
@@ -15,7 +15,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-2.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-2.json
@@ -15,7 +15,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-3.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-and-db-data-valid-3.json
@@ -15,7 +15,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-and-no-phone-extension.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-and-no-phone-extension.json
@@ -14,7 +14,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "SMITHB2",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-valid-1.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-valid-1.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "YOLOD",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Hotline-rollout"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-racfid-valid-2.json
+++ b/src/test/resources/fixtures/idm/get-user/with-racfid-valid-2.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "YOLOD",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Hotline-rollout"
     ],

--- a/src/test/resources/fixtures/idm/get-user/with-state-admin-id.json
+++ b/src/test/resources/fixtures/idm/get-user/with-state-admin-id.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "YULLC",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "phone_number": "4646464646",
     "phone_extension_number": "11",
     "permissions": [

--- a/src/test/resources/fixtures/idm/get-users/all-valid.json
+++ b/src/test/resources/fixtures/idm/get-users/all-valid.json
@@ -11,7 +11,7 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"
@@ -32,7 +32,7 @@
       "enabled": true,
       "status": "CONFIRMED",
       "racfid": "YOLOD",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Hotline-rollout"
       ],
@@ -56,7 +56,7 @@
       "enabled": true,
       "status": "CONFIRMED",
       "racfid": "SMITHBO",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "test"
       ],

--- a/src/test/resources/fixtures/idm/get-users/all-valid.json
+++ b/src/test/resources/fixtures/idm/get-users/all-valid.json
@@ -11,7 +11,6 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-users/search-valid.json
+++ b/src/test/resources/fixtures/idm/get-users/search-valid.json
@@ -11,7 +11,7 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"

--- a/src/test/resources/fixtures/idm/get-users/search-valid.json
+++ b/src/test/resources/fixtures/idm/get-users/search-valid.json
@@ -11,7 +11,6 @@
       "last_login_date_time": "2018-09-17 05:01:12",
       "enabled": true,
       "status": "FORCE_CHANGE_PASSWORD",
-      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "permissions": [
         "Snapshot-rollout",
         "RFA-rollout"

--- a/src/test/resources/fixtures/idm/users-search/valid.json
+++ b/src/test/resources/fixtures/idm/users-search/valid.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "YOLOD",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Hotline-rollout"
     ],
@@ -35,7 +35,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],
@@ -59,7 +59,7 @@
     "enabled": false,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/users-search/valid.json
+++ b/src/test/resources/fixtures/idm/users-search/valid.json
@@ -59,7 +59,6 @@
     "enabled": false,
     "status": "CONFIRMED",
     "racfid": "SMITHBO",
-    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "test"
     ],

--- a/src/test/resources/fixtures/idm/users-search/yolod.json
+++ b/src/test/resources/fixtures/idm/users-search/yolod.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "status": "CONFIRMED",
     "racfid": "YOLOD",
-    "registration_resubmit_date_time": "2018-11-05 10:53:24",
+    "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
     "permissions": [
       "Hotline-rollout"
     ],

--- a/src/test/resources/fixtures/idm/verify-user/verify-valid.json
+++ b/src/test/resources/fixtures/idm/verify-user/verify-valid.json
@@ -11,7 +11,6 @@
       "phone_number": "4646464646",
       "phone_extension_number": "11",
       "start_date": "1980-08-08",
-      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "roles": ["CWS-worker"]
     }
   }

--- a/src/test/resources/fixtures/idm/verify-user/verify-valid.json
+++ b/src/test/resources/fixtures/idm/verify-user/verify-valid.json
@@ -11,7 +11,7 @@
       "phone_number": "4646464646",
       "phone_extension_number": "11",
       "start_date": "1980-08-08",
-      "registration_resubmit_date_time": "2018-11-05 10:53:24",
+      "last_registration_resubmit_date_time": "2018-11-05 10:53:24",
       "roles": ["CWS-worker"]
     }
   }


### PR DESCRIPTION
### JIRA Issue Link
- [COG-852: Enrich User's Datamodel with Registration Re-submit DateTime for getUserById Response](https://osi-cwds.atlassian.net/browse/COG-852)

### Technical Description
registration_resubmit_date_time is renamed to last_registration_resubmit_date_time
cases with last_registration_resubmit_date_time==null are added

### Tests
- [ ] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
