### PR TITLE
COG-867 Change parameter of resendInvitationEmail API operation from email to User Id

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/IdmResource.java
+++ b/src/main/java/gov/ca/cwds/idm/IdmResource.java
@@ -355,12 +355,12 @@ public class IdmResource {
   @PreAuthorize("@userRoleService.isAdmin(principal) &&  " +
       " !@userRoleService.isCalsAdminStrongestRole(principal)")
   public ResponseEntity resendInvitationEmail(
-      @ApiParam(required = true, name = "email", value = "The email of the user", example = "email@example.com")
+      @ApiParam(required = true, value = "The unique user ID", example = "userId1")
       @NotNull
-      @RequestParam("email")
-          String email) {
+      @RequestParam("id")
+          String id) {
     try {
-      idmService.resendInvitationMessage(email);
+      idmService.resendInvitationMessage(id);
       return ResponseEntity.ok().build();
     } catch (UserNotFoundPerryException e) {
       return ResponseEntity.notFound().build();

--- a/src/main/java/gov/ca/cwds/idm/service/IdmService.java
+++ b/src/main/java/gov/ca/cwds/idm/service/IdmService.java
@@ -29,6 +29,6 @@ public interface IdmService {
 
   List<UserAndOperation> getFailedOperations(LocalDateTime lastJobTime);
 
-  @PreAuthorize("@authorizationService.canResendInvitationMessage(#email)")
-  void resendInvitationMessage(@P("email") String email);
+  @PreAuthorize("@authorizationService.canResendInvitationMessage(#id)")
+  void resendInvitationMessage(@P("id") String id);
 }

--- a/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/IdmServiceImpl.java
@@ -232,8 +232,8 @@ public class IdmServiceImpl implements IdmService {
   }
 
   @Override
-  public void resendInvitationMessage(String email) {
-    cognitoServiceFacade.resendInvitationMessage(email);
+  public void resendInvitationMessage(String userId) {
+    cognitoServiceFacade.resendInvitationMessage(userId);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/idm/service/authorization/AuthorizationService.java
+++ b/src/main/java/gov/ca/cwds/idm/service/authorization/AuthorizationService.java
@@ -13,7 +13,7 @@ public interface AuthorizationService {
 
   boolean canUpdateUser(String userId);
 
-  boolean canResendInvitationMessage(String email);
+  boolean canResendInvitationMessage(String id);
 
   boolean canEditRoles(User user);
 

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeImpl.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeImpl.java
@@ -8,6 +8,7 @@ import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.EMAIL_DELIVERY;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.buildCreateUserAttributes;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.createDelimitedAttribute;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.getDelimitedAttributeValue;
+import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.getEmail;
 import static gov.ca.cwds.service.messages.MessageCode.ERROR_CONNECT_TO_IDM;
 import static gov.ca.cwds.service.messages.MessageCode.ERROR_GET_USER_FROM_IDM;
 import static gov.ca.cwds.service.messages.MessageCode.ERROR_UPDATE_USER_IN_IDM;
@@ -293,7 +294,9 @@ public class CognitoServiceFacadeImpl implements CognitoServiceFacade {
   }
 
   @Override
-  public UserType resendInvitationMessage(String email) {
+  public UserType resendInvitationMessage(String userId) {
+    UserType cognitoUser = getCognitoUserById(userId);
+    String email = getEmail(cognitoUser);
     AdminCreateUserRequest request = createResendEmailRequest(email);
     return identityProvider.adminCreateUser(request).getUser();
   }

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoUtils.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoUtils.java
@@ -10,7 +10,6 @@ import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.EMAIL;
 import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.EMAIL_VERIFIED;
 import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.FIRST_NAME;
 import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.LAST_NAME;
-import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.PHONE_NUMBER;
 import static gov.ca.cwds.idm.service.cognito.StandardUserAttribute.RACFID_STANDARD;
 import static gov.ca.cwds.util.Utils.toSet;
 import static gov.ca.cwds.util.Utils.toUpperCase;
@@ -54,6 +53,10 @@ public class CognitoUtils {
 
   public static String getCountyName(UserType cognitoUser) {
     return getAttributeValue(cognitoUser, COUNTY.getName());
+  }
+
+  public static String getEmail(UserType cognitoUser) {
+    return getAttributeValue(cognitoUser, EMAIL.getName());
   }
 
   public static Set<String> getPermissions(UserType cognitoUser) {

--- a/src/test/java/gov/ca/cwds/idm/ResendInvitationEmailTest.java
+++ b/src/test/java/gov/ca/cwds/idm/ResendInvitationEmailTest.java
@@ -16,24 +16,24 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 public class ResendInvitationEmailTest extends BaseIdmResourceTest {
 
-  private static final String YOLO_COUNTY_USERS_EMAIL = "julio@gmail.com";
+  private static final String USER_WITH_RACFID_ID_EMAIL = "julio@gmail.com";
 
   @Test
   @WithMockCustomUser(county = "OtherCounty")
   public void testResendInvitationEmailWithDifferentCounty() throws Exception {
-    assertResendEmailUnauthorized(YOLO_COUNTY_USERS_EMAIL);
+    assertResendEmailUnauthorized(USER_WITH_RACFID_ID);
   }
 
   @Test
   @WithMockCustomUser(roles = {OFFICE_ADMIN}, adminOfficeIds = {"otherOfficeId"})
   public void testResendInvitationEmailWithOfficeRole() throws Exception {
-    assertResendEmailUnauthorized(YOLO_COUNTY_USERS_EMAIL);
+    assertResendEmailUnauthorized(USER_WITH_RACFID_ID);
   }
 
   @Test
   @WithMockCustomUser(roles = {"OtherRole"})
   public void testResendInvitationEmailWithOtherRole() throws Exception {
-    assertResendEmailUnauthorized(YOLO_COUNTY_USERS_EMAIL);
+    assertResendEmailUnauthorized(USER_WITH_RACFID_ID);
   }
 
   @Test
@@ -48,9 +48,9 @@ public class ResendInvitationEmailTest extends BaseIdmResourceTest {
     assertResendEmailWorksFine();
   }
 
-  private void assertResendEmailUnauthorized(String email) throws Exception {
+  private void assertResendEmailUnauthorized(String id) throws Exception {
     mockMvc
-        .perform(MockMvcRequestBuilders.get("/idm/users/resend?email=" + email))
+        .perform(MockMvcRequestBuilders.get("/idm/users/resend?id=" + id))
         .andExpect(MockMvcResultMatchers.status().isUnauthorized())
         .andReturn();
   }
@@ -58,10 +58,10 @@ public class ResendInvitationEmailTest extends BaseIdmResourceTest {
   private void assertResendEmailWorksFine() throws Exception {
     AdminCreateUserRequest request =
         ((TestCognitoServiceFacade) cognitoServiceFacade)
-            .createResendEmailRequest(YOLO_COUNTY_USERS_EMAIL);
+            .createResendEmailRequest(USER_WITH_RACFID_ID_EMAIL);
 
     UserType user = new UserType();
-    user.setUsername(USER_WITH_RACFID_ID);
+    user.setUsername(USER_WITH_RACFID_ID_EMAIL);
     user.setEnabled(true);
     user.setUserStatus("FORCE_CHANGE_PASSWORD");
 
@@ -71,7 +71,7 @@ public class ResendInvitationEmailTest extends BaseIdmResourceTest {
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(
-                "/idm/users/resend?email="+YOLO_COUNTY_USERS_EMAIL))
+                "/idm/users/resend?id=" + USER_WITH_RACFID_ID))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andReturn();
   }


### PR DESCRIPTION
### JIRA Issue Link
- [COG-867: Change parameter of resendInvitationEmail API operation from email to User Id](https://osi-cwds.atlassian.net/browse/COG-867)

### Technical Description
This task has two goals:
* Keep API consistent by using user Id as key identifying user in all user related operations.
* Spare some additional operations in UI (obtaining email by id) and backend (search by email).

### Tests
- [x] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
