### PR TITLE
COG-1065: Office information is not displayed for Global Admins

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/OfficeService.java
+++ b/src/main/java/gov/ca/cwds/idm/service/OfficeService.java
@@ -3,6 +3,7 @@ package gov.ca.cwds.idm.service;
 import static gov.ca.cwds.config.api.idm.Roles.COUNTY_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.OFFICE_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.STATE_ADMIN;
+import static gov.ca.cwds.config.api.idm.Roles.SUPER_ADMIN;
 import static gov.ca.cwds.service.messages.MessageCode.NOT_AUTHORIZED_TO_GET_MANAGED_OFFICES_LIST;
 import static gov.ca.cwds.util.CurrentAuthenticatedUserUtil.getCurrentUser;
 import static gov.ca.cwds.util.CurrentAuthenticatedUserUtil.getCurrentUserCountyName;
@@ -45,6 +46,7 @@ public class OfficeService {
     List<Office> offices;
 
     switch (UserRolesService.getStrongestAdminRole(currentUser)) {
+      case SUPER_ADMIN:
       case STATE_ADMIN:
         offices = officeRepository.findActiveOffices();
         break;

--- a/src/test/java/gov/ca/cwds/idm/OfficesTest.java
+++ b/src/test/java/gov/ca/cwds/idm/OfficesTest.java
@@ -4,6 +4,7 @@ import static gov.ca.cwds.config.api.idm.Roles.CALS_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.COUNTY_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.OFFICE_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.STATE_ADMIN;
+import static gov.ca.cwds.config.api.idm.Roles.SUPER_ADMIN;
 import static gov.ca.cwds.idm.util.AssertFixtureUtils.assertStrict;
 
 import gov.ca.cwds.idm.util.WithMockCustomUser;
@@ -17,6 +18,12 @@ public class OfficesTest extends BaseIdmIntegrationTest {
   @Test
   @WithMockCustomUser(roles = {STATE_ADMIN})
   public void testGetAdminOfficesStateAdmin() throws Exception {
+    assertAllAdminOffices();
+  }
+
+  @Test
+  @WithMockCustomUser(roles = {SUPER_ADMIN})
+  public void testGetAdminOfficesSuperAdmin() throws Exception {
     assertAllAdminOffices();
   }
 


### PR DESCRIPTION
### JIRA Issue Link
- [COG-1065: Office information is not displayed for Global Admins](https://osi-cwds.atlassian.net/browse/COG-1065)

### Technical Description
Test Steps:
1. Log into CARES as Global admin
2. Navigate to Manage Users

Expected Result:
1. All columns populated correctly.
2. Ability to filter by Office Name.

Actual result:
1. Office Name is not populated with correct data.
2. Offices are not listed in the Filter by Office drop down

### Tests
- [ ] I have included unit tests 
- [x] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
