### PR TITLE
COG-1164: Reset MAX_LOGIN_ATTEMPTS to "0" after unlocking user

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/service/cognito/attribute/CustomUserAttribute.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/attribute/CustomUserAttribute.java
@@ -8,7 +8,8 @@ public enum CustomUserAttribute implements UserAttribute {
   RACFID_CUSTOM("custom:RACFID"),
   RACFID_CUSTOM_2("custom:RACFId"),
   PHONE_EXTENSION("custom:PhoneExtension"),
-  IS_LOCKED("custom:accountLocked");
+  IS_LOCKED("custom:accountLocked"),
+  MAX_LOGIN_ATTEMPTS("custom:numLoginAttempts");
 
   private String name;
 

--- a/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoRequestHelper.java
+++ b/src/main/java/gov/ca/cwds/idm/service/cognito/util/CognitoRequestHelper.java
@@ -1,6 +1,7 @@
 package gov.ca.cwds.idm.service.cognito.util;
 
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.IS_LOCKED;
+import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.MAX_LOGIN_ATTEMPTS;
 import static gov.ca.cwds.idm.service.cognito.attribute.UserLockStatus.FALSE;
 import static gov.ca.cwds.idm.service.cognito.util.CognitoUtils.buildCreateUserAttributes;
 import static gov.ca.cwds.util.Utils.toLowerCase;
@@ -19,7 +20,7 @@ import com.amazonaws.services.cognitoidp.model.MessageActionType;
 import gov.ca.cwds.idm.dto.User;
 import gov.ca.cwds.idm.service.cognito.CognitoProperties;
 import gov.ca.cwds.idm.service.cognito.dto.CognitoUsersSearchCriteria;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Service;
 @Profile("idm")
 public final class CognitoRequestHelper {
 
+  public static final String RESET_MAX_LOGIN_ATTEMPTS_COUNT = "0";
   private CognitoProperties properties;
 
   @Autowired
@@ -37,8 +39,17 @@ public final class CognitoRequestHelper {
   }
 
   public List<AttributeType> getLockedAttributeType() {
-    return Collections.singletonList(
-        new AttributeType().withName(IS_LOCKED.getName()).withValue(FALSE.getValue()));
+    final AttributeType isLockedAttributeType =
+        new AttributeType()
+            .withName(IS_LOCKED.getName())
+            .withValue(FALSE.getValue());
+
+    final AttributeType loginAttemptsAttributeType =
+        new AttributeType()
+            .withName(MAX_LOGIN_ATTEMPTS.getName())
+            .withValue(RESET_MAX_LOGIN_ATTEMPTS_COUNT);
+
+    return Arrays.asList(isLockedAttributeType, loginAttemptsAttributeType);
   }
 
   public AdminUpdateUserAttributesRequest getAdminUpdateUserAttributesRequest(

--- a/src/test/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeTest.java
+++ b/src/test/java/gov/ca/cwds/idm/service/cognito/CognitoServiceFacadeTest.java
@@ -4,6 +4,7 @@ import static gov.ca.cwds.config.api.idm.Roles.COUNTY_ADMIN;
 import static gov.ca.cwds.config.api.idm.Roles.CWS_WORKER;
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.COUNTY;
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.IS_LOCKED;
+import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.MAX_LOGIN_ATTEMPTS;
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.OFFICE;
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.PERMISSIONS;
 import static gov.ca.cwds.idm.service.cognito.attribute.CustomUserAttribute.PHONE_EXTENSION;
@@ -16,7 +17,6 @@ import static gov.ca.cwds.idm.service.cognito.attribute.StandardUserAttribute.FI
 import static gov.ca.cwds.idm.service.cognito.attribute.StandardUserAttribute.LAST_NAME;
 import static gov.ca.cwds.idm.service.cognito.attribute.StandardUserAttribute.PHONE_NUMBER;
 import static gov.ca.cwds.idm.service.cognito.attribute.StandardUserAttribute.RACFID_STANDARD;
-import static gov.ca.cwds.idm.service.cognito.attribute.UserLockStatus.FALSE;
 import static gov.ca.cwds.idm.util.TestCognitoServiceFacade.USERPOOL;
 import static gov.ca.cwds.idm.util.TestHelper.getTestCognitoProperties;
 import static gov.ca.cwds.idm.util.TestUtils.attr;
@@ -297,13 +297,21 @@ public class CognitoServiceFacadeTest {
     assertThat(request.getUsername(), is(USER_ID));
     assertThat(request.getUserPoolId(), is(USERPOOL));
     assertThat(request.getUserAttributes(), is(getCognitoRequestHelper().getLockedAttributeType()));
-    final Optional<AttributeType> lockedAttributeType =
+    final Optional<AttributeType> isLockedAttributeType =
         request.getUserAttributes().stream()
             .filter(attributeType -> Objects.equals(attributeType.getName(), IS_LOCKED.getName()))
             .findAny();
-    assertTrue(lockedAttributeType.isPresent());
-    assertThat(
-        lockedAttributeType.get().getValue(), is(String.valueOf(FALSE.getValue())));
+    assertTrue(isLockedAttributeType.isPresent());
+    assertThat(isLockedAttributeType.get().getValue(), is("false"));
+
+    final Optional<AttributeType> loginAttemptsAttributeType =
+        request.getUserAttributes().stream()
+            .filter(
+                attributeType ->
+                    Objects.equals(attributeType.getName(), MAX_LOGIN_ATTEMPTS.getName()))
+            .findAny();
+    assertTrue(loginAttemptsAttributeType.isPresent());
+    assertThat(loginAttemptsAttributeType.get().getValue(), is("0"));
   }
 
   @Test


### PR DESCRIPTION
### JIRA Issue Link
- [COG-1164: Unlock user as an admin in CWS-CARES - Detail View](https://osi-cwds.atlassian.net/browse/COG-1164)

### Technical Description
Reset Cognito custom attribute custom:numLoginAttempts to "0" after unlocking user

### Tests
- [X] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
N/A

### Technical debt
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
