### PR TITLE
COG-1152 - admin_name and user_name in audit_event should be in "Last Name, First Name" format for all events

### DIFF
--- a/src/main/java/gov/ca/cwds/idm/event/UserCausedChangeLogEvent.java
+++ b/src/main/java/gov/ca/cwds/idm/event/UserCausedChangeLogEvent.java
@@ -11,7 +11,7 @@ public abstract class UserCausedChangeLogEvent extends UserChangeLogEvent {
     super(user);
 
     setUserLogin(user.getId());
-    setAdminName(createUserFullNameString(user));
+    setAdminName(formatUserFullName(user));
     setAdminRole(Roles.toRolesNamesString(user));
   }
 }

--- a/src/main/java/gov/ca/cwds/idm/event/UserChangeLogEvent.java
+++ b/src/main/java/gov/ca/cwds/idm/event/UserChangeLogEvent.java
@@ -21,11 +21,11 @@ public abstract class UserChangeLogEvent extends AuditEvent<UserChangeLogRecord>
     setOfficeId(user.getOfficeId());
     setUserRoles(Roles.toRolesNamesString(user));
     setUserId(user.getId());
-    setUserName(createUserFullNameString(user));
+    setUserName(formatUserFullName(user));
   }
 
-  static String createUserFullNameString(User user) {
-    return user.getFirstName() + " " + user.getLastName();
+  static String formatUserFullName(User user) {
+    return user.getLastName() + ", " + user.getFirstName();
   }
 
   final void setAdminRole(String adminRole) {

--- a/src/test/java/gov/ca/cwds/idm/event/UserChangeLogEventTest.java
+++ b/src/test/java/gov/ca/cwds/idm/event/UserChangeLogEventTest.java
@@ -81,7 +81,7 @@ public class UserChangeLogEventTest {
     assertEquals(TEST_COUNTY, changeLogRecord.getCountyName());
     assertEquals(TEST_OFFICE_ID, changeLogRecord.getOfficeId());
     assertEquals(TEST_USER_ID, changeLogRecord.getUserId());
-    assertEquals(TEST_FIRST_NAME + " " + TEST_LAST_NAME, changeLogRecord.getUserName());
+    assertEquals(TEST_LAST_NAME + ", " + TEST_FIRST_NAME, changeLogRecord.getUserName());
     assertEquals(CAP_EVENT_SOURCE, userCreatedEvent.getEventSource());
     assertEquals(ADMIN_LOGIN, userCreatedEvent.getUserLogin());
   }
@@ -102,7 +102,7 @@ public class UserChangeLogEventTest {
     User user = mockUser();
     UserRegistrationResentEvent event = new UserRegistrationResentEvent(user);
     assertEquals(UserRegistrationResentEvent.EVENT_TYPE_REGISTRATION_RESENT, event.getEventType());
-    assertEquals(TEST_FIRST_NAME + " " + TEST_LAST_NAME, event.getEvent().getUserName());
+    assertEquals(TEST_LAST_NAME + ", " + TEST_FIRST_NAME, event.getEvent().getUserName());
     assertEquals(String.join(", ", getRoleNameById(CWS_WORKER), getRoleNameById(COUNTY_ADMIN)),
         event.getEvent().getUserRoles());
   }
@@ -218,8 +218,8 @@ public class UserChangeLogEventTest {
     assertThat(event.getUserLogin(), is(TEST_USER_ID));
     assertThat(event.getEvent().getUserId(), is(TEST_USER_ID));
     assertThat(event.getEventType(), is("User Password Changed"));
-    assertThat(event.getEvent().getAdminName(), is("testFirstName testLastName"));
-    assertThat(event.getEvent().getUserName(), is("testFirstName testLastName"));
+    assertThat(event.getEvent().getAdminName(), is("testLastName, testFirstName"));
+    assertThat(event.getEvent().getUserName(), is("testLastName, testFirstName"));
     assertThat(event.getEvent().getAdminRole(), is("CWS Worker, County Administrator"));
     assertThat(event.getEvent().getUserRoles(), is("CWS Worker, County Administrator"));
     assertThat(event.getEvent().getOldValue(), is(nullValue()));


### PR DESCRIPTION

### JIRA Issue Link
- [COG-1152: admin_name and user_name in audit_event should be in "Last Name, First Name" format for all events](https://osi-cwds.atlassian.net/browse/COG-1152)

### Technical Description
Format admin_name and user_name as "Last Name, First Name" for all user events

### Tests
- [X] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added.-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
N/A

### Technical debt
<!--- If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.-->
<!--- If you're unsure about any of these, don't hesitate to ask.-->
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
